### PR TITLE
use socks5 proxy in the request

### DIFF
--- a/client/v1/request.js
+++ b/client/v1/request.js
@@ -2,6 +2,7 @@ var _ = require("underscore");
 var Promise = require("bluebird");
 var request = require('request-promise');
 var JSONbig = require('json-bigint');
+var Agent = require('socks5-https-client/lib/Agent');
 
 function Request(session) {
     this._id = _.uniqueId();
@@ -51,9 +52,14 @@ Request.requestClient = request.defaults({});
 
 
 Request.setProxy = function (proxyUrl) {
-    if(!Helpers.isValidUrl(proxyUrl))
+    /*if(!Helpers.isValidUrl(proxyUrl))
         throw new Error("`proxyUrl` argument is not an valid url")
-    var object = { 'proxy': proxyUrl };    
+    var object = { 'proxy': proxyUrl };    */
+    var object ={agentClass: Agent,
+    agentOptions: {
+        socksHost: proxyUrl,
+        socksPort: 55555
+    }};
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     Request.requestClient = request.defaults(object);
 }

--- a/client/v1/request.js
+++ b/client/v1/request.js
@@ -50,20 +50,23 @@ Request.defaultHeaders = {
 
 Request.requestClient = request.defaults({});
 
-
 Request.setProxy = function (proxyUrl) {
-    /*if(!Helpers.isValidUrl(proxyUrl))
+    if(!Helpers.isValidUrl(proxyUrl))
         throw new Error("`proxyUrl` argument is not an valid url")
-    var object = { 'proxy': proxyUrl };    */
-    var object ={agentClass: Agent,
-    agentOptions: {
-        socksHost: proxyUrl,
-        socksPort: 55555
-    }};
+    var object = { 'proxy': proxyUrl };    
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     Request.requestClient = request.defaults(object);
 }
 
+Request.setSocks5Proxy = function (host, port) {
+    var object = { agentClass: Agent,
+    agentOptions: {
+        socksHost: host, // Defaults to 'localhost'.
+        socksPort: port // Defaults to 1080.
+    }};
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    Request.requestClient = request.defaults(object);
+}
 
 Object.defineProperty(Request.prototype, "session", {
     get: function() { 

--- a/client/v1/session.js
+++ b/client/v1/session.js
@@ -59,8 +59,8 @@ Object.defineProperty(Session.prototype, "proxyUrl", {
         return this._proxyUrl;
     },
     set: function(val) {
-        if(!Helpers.isValidUrl(val) && val !== null)
-            throw new Error("`proxyUrl` argument is not an valid url") 
+        // if(!Helpers.isValidUrl(val) && val !== null)
+        //     throw new Error("`proxyUrl` argument is not an valid url") 
         this._proxyUrl = val;
     }
 });

--- a/client/v1/session.js
+++ b/client/v1/session.js
@@ -58,9 +58,9 @@ Object.defineProperty(Session.prototype, "proxyUrl", {
     get: function() { 
         return this._proxyUrl;
     },
-    set: function(val) {
-        // if(!Helpers.isValidUrl(val) && val !== null)
-        //     throw new Error("`proxyUrl` argument is not an valid url") 
+    set: function (val) {
+        if (!Helpers.isValidUrl(val) && val !== null)
+            throw new Error("`proxyUrl` argument is not an valid url")
         this._proxyUrl = val;
     }
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "tough-cookie": "^2.3.1",
     "tough-cookie-filestore": "0.0.1",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.2.2"
+    "underscore.string": "^3.2.2",
+    "socks5-https-client": "^1.1.3"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",

--- a/tests/run.js
+++ b/tests/run.js
@@ -33,6 +33,7 @@ mkdirp.sync(__dirname + '/tmp');
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 // Client.Request.setProxy('http://127.0.0.1:8888')
+// Client.Request.setSocks5Proxy("127.0.0.1", 8888);
 
 describe("Sessions", function () {
     before(function (done) {


### PR DESCRIPTION
Added socks5 proxy, used the dependence socks5-https-client (watching here https://www.npmjs.com/package/socks5-https-client).
For use, call the function setSocks5Proxy with host and port parameters:
Client.Request.setSocks5Proxy("127.0.0.1", 8888).
