### PR TITLE
When trying to logout by calling session.destroy(), an exception will be thrown

### DIFF
--- a/client/v1/session.js
+++ b/client/v1/session.js
@@ -108,7 +108,7 @@ Session.prototype.getAccount = function () {
 
 
 Session.prototype.destroy = function () {
-    this.cookiesStore.destroy();
+    this._cookiesStore.destroy();
     return new Request(this)
         .setMethod('POST')
         .setResource('logout')


### PR DESCRIPTION
The reason for this is because the name for the CookiesStore object should be '_cookiesStore' instead of 'cookiesStore'.