### PR TITLE
Add support for Saved Feed and save/unsave medias

### DIFF
--- a/client/v1.js
+++ b/client/v1.js
@@ -26,6 +26,7 @@ InstagramV1.ThreadItem = require('./v1/thread-item');
 InstagramV1.QE = require('./v1/qe');
 InstagramV1.Upload = require('./v1/upload');
 InstagramV1.discover = require('./v1/discover');
+InstagramV1.Save = require('./v1/save');
 
 var creator = require('./v1/account-creator');
 InstagramV1.AccountCreator = creator.AccountCreator;
@@ -44,6 +45,7 @@ InstagramV1.Feed.Timeline = require('./v1/feeds/timeline-feed');
 InstagramV1.Feed.UserMedia = require('./v1/feeds/user-media');
 InstagramV1.Feed.SelfLiked = require('./v1/feeds/self-liked');
 InstagramV1.Feed.MediaComments = require('./v1/feeds/media-comments');
+InstagramV1.Feed.SavedMedia = require('./v1/feeds/saved-media');
 
 InstagramV1.Web = {};
 InstagramV1.Web.Request = require('./v1/web/web-request');

--- a/client/v1/constants.js
+++ b/client/v1/constants.js
@@ -32,6 +32,7 @@ const ROUTES = {
     locationFeed: 'feed/location/<%= id %>/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>rank_token=<%= rankToken %>',
     followingFeed: 'friendships/<%= id %>/following/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>rank_token=<%= rankToken %>',
     followersFeed: 'friendships/<%= id %>/followers/<%= maxId ? ("?max_id=" + maxId) : "" %>',
+    savedFeed: 'feed/saved/',
     accountsSearch: 'users/search/?is_typehead=true&q=<%= encodeURIComponent(query) %>&rank_token=<%= rankToken %>',
     hashtagsSearch: 'tags/search/?count=50&q=<%= encodeURIComponent(query) %>&rank_token=<%= rankToken %>',
     locationsSearch: 'fbsearch/places/?count=50&query=<%= encodeURIComponent(query) %>&rank_token=<%= rankToken %>',
@@ -60,7 +61,9 @@ const ROUTES = {
     autocompleteUserList: 'friendships/autocomplete_user_list/?version=2&followinfo=True',
     megaphoneLog: 'megaphone/log/',
     block: 'friendships/block/<%= id %>/',
-    unblock: 'friendships/unblock/<%= id %>/'
+    unblock: 'friendships/unblock/<%= id %>/',
+    save: 'media/<%= id %>/save/',
+    unsave: 'media/<%= id %>/unsave/'
 };
 
 

--- a/client/v1/feeds/saved-media.js
+++ b/client/v1/feeds/saved-media.js
@@ -1,0 +1,74 @@
+var _ = require('underscore');
+
+function SavedFeed(session, limit) {
+    this.cursor = null;
+    this.moreAvailable = null;
+    this.session = session;
+    this.allMedia = [];
+    this.timeout = 10 * 60 * 1000; // 10 minutes
+    this.limit = limit;
+}
+
+module.exports = SavedFeed;
+var Media = require('../media');
+var Request = require('../request');
+var Helpers = require('../../../helpers');
+var Account = require('../account');
+
+
+SavedFeed.prototype.setCursor = function (maxId) {
+    this.cursor = maxId;
+};
+
+
+SavedFeed.prototype.getCursor = function () {
+    return this.cursor;
+};
+
+
+SavedFeed.prototype.isMoreAvailable = function () {
+    return !!this.moreAvailable;
+};
+
+
+SavedFeed.prototype.get = function () {
+    var that = this;
+
+    return new Request(that.session)
+      .setMethod('POST')
+      .setResource('savedFeed')
+      .generateUUID()
+      .setData({})
+      .signPayload()
+      .send()
+      .then(function(data) {
+        that.moreAvailable = data.more_available;
+        var lastOne = _.last(data.items);
+        if (that.moreAvailable && lastOne) {
+            that.setCursor(lastOne.id);
+        }
+        return _.map(data.items, function (medium) {
+            return new Media(that.session, medium.media);
+        });
+      })
+};
+
+
+SavedFeed.prototype.all = function () {
+    var that = this;
+    return this.get().then(function (medias) {
+        that.allMedia = that.allMedia.concat(medias);
+        var exceedLimit = false;
+        if (that.limit && that.allMedia.length > that.limit)
+            exceedLimit = true;
+        if (that.moreAvailable && !exceedLimit) {
+            return that.all();
+        } else {
+            return that.allMedia;
+        }
+    })
+};
+
+SavedFeed.prototype.allSafe = function () {
+    return this.all().timeout(this.timeout);
+};

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -35,6 +35,7 @@ Media.prototype.parseParams = function (json) {
     hash.originalHeight = json.original_height;
     hash.mediaType = json.media_type;
     hash.deviceTimestamp = json.device_timestamp;
+
     if(json.view_count)
         hash.viewCount = json.view_count;
     if(_.isObject(json.location)) {
@@ -51,7 +52,7 @@ Media.prototype.parseParams = function (json) {
     if (_.isObject(json.image_versions2))
         hash.images = json.image_versions2.candidates;
     this.comments = _.map(json.comments, function(comment) {
-        return new Comment(that.session, comment); 
+        return new Comment(that.session, comment);
     });
     this.account = new Account(that.session, json.user);
     return hash;
@@ -112,7 +113,7 @@ Media.delete = function(session, mediaId) {
         .signPayload()
         .send()
         .then(function (json) {
-            if(json.did_delete) return;    
+            if(json.did_delete) return;
             throw new Exceptions.RequestError({
                 messaage: 'Not posible to delete medium!'
             })
@@ -122,10 +123,10 @@ Media.delete = function(session, mediaId) {
 Media.configurePhoto = function (session, uploadId, caption, width, height) {
     if(_.isEmpty(uploadId))
         throw new Error("Upload argument must be upload valid upload id");
-    if(!caption) caption = "";    
-    if(!width) width = 800;    
-    if(!height) height = 800; 
-    const CROP = 1;   
+    if(!caption) caption = "";
+    if(!width) width = 800;
+    if(!height) height = 800;
+    const CROP = 1;
     var payload = pruned({
         source_type: "4",
         caption: caption,
@@ -139,7 +140,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
         extra: {
             source_width: width,
             source_height: height
-        }    
+        }
     });
     payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
     payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));

--- a/client/v1/save.js
+++ b/client/v1/save.js
@@ -1,0 +1,51 @@
+var Resource = require('./resource');
+var util = require("util");
+var _ = require("underscore");
+
+
+function Save(session, params) {
+    Resource.apply(this, arguments);
+}
+
+module.exports = Save;
+util.inherits(Save, Resource);
+
+var Request = require('./request');
+
+
+Save.prototype.parseParams = function (json) {
+    return json || {};
+};
+
+
+Save.create = function(session, mediaId) {
+    return new Request(session)
+        .setMethod('POST')
+        .setResource('save', {id: mediaId})
+        .generateUUID()
+        .setData({
+            media_id: mediaId,
+            src: "profile"
+        })
+        .signPayload()
+        .send()
+        .then(function(data) {
+            return new Save(session, {});
+        })
+}
+
+Save.destroy = function(session, mediaId) {
+    return new Request(session)
+        .setMethod('POST')
+        .setResource('unsave', {id: mediaId})
+        .generateUUID()
+        .setData({
+            media_id: mediaId,
+            src: "profile"
+        })
+        .signPayload()
+        .send()
+        .then(function(data) {
+            return new Save(session, {});
+        })
+}


### PR DESCRIPTION
Fixes #83

I adding some missing functionality in this library. 

Getting saved media feed:
```
  let savedMediaFeed = new Client.Feed.SavedMedia(session);
  savedMediaFeed.get().then(medias => {
    console.log(medias);
  });
```

Save/Unsave: (yield is `co-generator` to trigger Promise)
```
  yield Client.Save.create(session, media.id);
  yield Client.Save.destroy(session, media.id);
```