### PR TITLE
Save video params to Media

### DIFF
--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -55,6 +55,13 @@ Media.prototype.parseParams = function (json) {
         return new Comment(that.session, comment);
     });
     this.account = new Account(that.session, json.user);
+    if (json.media_type === 2) {
+      hash.video = {
+        versions: json.video_versions,
+        has_audio: json.has_audio,
+        duration: json.video_duration
+      };
+    }
     return hash;
 };
 


### PR DESCRIPTION
Media object now has:

```
video: {
  versions: [ url: String, width: Number, height: Number, type: Number ],
  has_audio: Boolean,
  duration: Number
}
```

But only if media_type is 2. The URL is a direct link to a MP4 file.