### PR TITLE
Fix for setHeaders default headers bug

### DIFF
--- a/client/v1/request.js
+++ b/client/v1/request.js
@@ -17,7 +17,7 @@ function Request(session) {
     this._request.options = {
         gzip: true 
     };
-    this._request.headers = Request.defaultHeaders;
+    this._request.headers=_.extend({},Request.defaultHeaders);
     this.attemps = 2;
     if(session) {
         this.session = session;            


### PR DESCRIPTION
#109
Looks like default headers was passed as reference, not as value