### PR TITLE
Transcode timeout fix and video duration check

### DIFF
--- a/client/v1/exceptions.js
+++ b/client/v1/exceptions.js
@@ -350,3 +350,10 @@ function AccountRegistrationError(message, json) {
 
 util.inherits(AccountRegistrationError, APIError);
 exports.AccountRegistrationError = AccountRegistrationError;
+
+function TranscodeTimeoutError() {
+    this.name = "Transcode Error";
+    this.message = "Server did not transcoded uploaded video in time";
+}
+util.inherits(TranscodeTimeoutError, APIError);
+exports.TranscodeTimeoutError = TranscodeTimeoutError;

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -247,7 +247,7 @@ Media.configureVideo = function (session, uploadId, caption, durationms, delay) 
             .setData(JSON.parse(payload))
             .generateUUID()
             .signPayload()
-            .send()
+            .send({},3)
             .then(function(json) {
                 return new Media(session, json.media)
             })

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -5,6 +5,7 @@ var crypto = require('crypto');
 var pruned = require('./json-pruned');
 var fs = require('fs');
 var request = require('request-promise');
+var Promise = require("bluebird");
 
 
 function Media(session, params) {
@@ -201,14 +202,18 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
         })
 };
 
-Media.configureVideo = function (session, uploadId, caption, durationms) {
+Media.configureVideo = function (session, uploadId, caption, durationms, delay) {
     if(_.isEmpty(uploadId))
         throw new Error("Upload argument must be upload valid upload id");
     if(typeof(durationms)==='undefined')
         throw new Error("Durationms argument must be upload valid video duration");
     var duration = durationms/1000;
     if(!caption) caption = "";
-    return session.getAccountId()
+    if(!delay || typeof delay != "number") delay = 6500;
+    return Promise.delay(delay)
+        .then(function(){
+            return session.getAccountId()
+        })
         .then(function(accountId){
             var payload = pruned({
                 "filter_type": "0",

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -247,9 +247,13 @@ Media.configureVideo = function (session, uploadId, caption, durationms, delay) 
             .setData(JSON.parse(payload))
             .generateUUID()
             .signPayload()
-            .send({},3)
+            .send()
             .then(function(json) {
                 return new Media(session, json.media)
+            })
+            .catch(Exceptions.TranscodeTimeoutError,function(error){
+                //Well, we just want to repeat our request. Dunno why this is happening and we should not let our users deal with this crap themselves.
+                return Media.configureVideo(session,uploadId,caption,durationms,delay);
             })
     })
 };

--- a/client/v1/request.js
+++ b/client/v1/request.js
@@ -363,6 +363,8 @@ Request.prototype.send = function (options, attemps) {
             var json = response.body;
             if (_.isObject(json) && json.status == "ok")
                 return _.omit(response.body, 'status');
+            if (_.isString(json.message) && json.message.toLowerCase().indexOf('transcode timeout') !== -1)
+                throw new Exceptions.TranscodeTimeoutError();
             throw new Exceptions.RequestError(json);
         })
         .catch(function(error) {

--- a/client/v1/upload.js
+++ b/client/v1/upload.js
@@ -69,6 +69,7 @@ Upload.video = function(session,videoBufferOrPath,photoStreamOrPath){
     return Helpers.pathToBuffer(videoBufferOrPath)
         .then(function(buffer){
             var duration = _getVideoDurationMs(buffer);
+            if(duration > 63000) throw new Error('Video is too long. Maximum: 63. Got: '+duration/1000);
             return request
             .setMethod('POST')
             .setBodyType('form')


### PR DESCRIPTION
There was an instagram-side error called "Transcode timeout". It happened when video was not transcoded in time. We should repeat our request.
Oh, and video length check added too.