### PR TITLE
Non-critical changes

### DIFF
--- a/client/v1/feeds/account-followers.js
+++ b/client/v1/feeds/account-followers.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function AccountFollowersFeed(session, accountId, limit) {
@@ -8,12 +9,10 @@ function AccountFollowersFeed(session, accountId, limit) {
     this.timeout = 10 * 60 * 1000;
     FeedBase.apply(this, arguments);
 }
-
-_.extend(AccountFollowersFeed.prototype, FeedBase.prototype);
+util.inherits(AccountFollowersFeed, FeedBase);
 
 module.exports = AccountFollowersFeed;
 var Request = require('../request');
-var Helpers = require('../../../helpers');
 var Account = require('../account');
 
 AccountFollowersFeed.prototype.get = function () {

--- a/client/v1/feeds/account-following.js
+++ b/client/v1/feeds/account-following.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function AccountFollowingFeed(session, accountId, limit) {
@@ -8,7 +9,7 @@ function AccountFollowingFeed(session, accountId, limit) {
     this.timeout = 10 * 60 * 1000;
     FeedBase.apply(this, arguments);
 }
-_.extend(AccountFollowingFeed.prototype, FeedBase.prototype);
+util.inherits(AccountFollowingFeed, FeedBase);
 
 module.exports = AccountFollowingFeed;
 var Request = require('../request');

--- a/client/v1/feeds/inbox.js
+++ b/client/v1/feeds/inbox.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function InboxFeed(session, limit) {
@@ -6,7 +7,7 @@ function InboxFeed(session, limit) {
     this.pendingRequestsTotal = null;
     FeedBase.apply(this, arguments);
 }
-_.extend(InboxFeed.prototype, FeedBase.prototype);
+util.inherits(InboxFeed, FeedBase);
 
 module.exports = InboxFeed;
 var Thread = require('../thread');

--- a/client/v1/feeds/location-media.js
+++ b/client/v1/feeds/location-media.js
@@ -1,11 +1,12 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function LocationMediaFeed(session, locationId) {
     this.locationId = locationId;
     FeedBase.apply(this, arguments);
 }
-_.extend(LocationMediaFeed.prototype, FeedBase.prototype);
+util.inherits(LocationMediaFeed, FeedBase);
 
 module.exports = LocationMediaFeed;
 var Media = require('../media');

--- a/client/v1/feeds/media-comments.js
+++ b/client/v1/feeds/media-comments.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function MediaCommentsFeed(session, mediaId, limit) {
@@ -6,7 +7,7 @@ function MediaCommentsFeed(session, mediaId, limit) {
     this.limit = limit;
     FeedBase.apply(this, arguments);
 }
-_.extend(MediaCommentsFeed.prototype, FeedBase.prototype);
+util.inherits(MediaCommentsFeed, FeedBase);
 
 module.exports = MediaCommentsFeed;
 var Request = require('../request');

--- a/client/v1/feeds/saved-media.js
+++ b/client/v1/feeds/saved-media.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function SavedFeed(session, limit) {
@@ -6,13 +7,11 @@ function SavedFeed(session, limit) {
     this.limit = limit;
     FeedBase.apply(this, arguments);
 }
-_.extend(SavedFeed.prototype, FeedBase.prototype);
+util.inherits(SavedFeed, FeedBase);
 
 module.exports = SavedFeed;
 var Media = require('../media');
 var Request = require('../request');
-var Helpers = require('../../../helpers');
-var Account = require('../account');
 
 SavedFeed.prototype.get = function () {
     var that = this;

--- a/client/v1/feeds/self-liked.js
+++ b/client/v1/feeds/self-liked.js
@@ -1,17 +1,16 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function SelfLikedFeed(session) {
     this.session = session;
     FeedBase.apply(this, arguments);
 }
-_.extend(SelfLikedFeed.prototype, FeedBase.prototype);
+util.inherits(SelfLikedFeed, FeedBase);
 
 module.exports = SelfLikedFeed;
 var Media = require('../media');
 var Request = require('../request');
-var Helpers = require('../../../helpers');
-var Exceptions = require('../exceptions');
 
 
 SelfLikedFeed.prototype.get = function () {

--- a/client/v1/feeds/tagged-media.js
+++ b/client/v1/feeds/tagged-media.js
@@ -1,11 +1,12 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function TaggedMediaFeed(session, tag) {
     this.tag = tag;
     FeedBase.apply(this, arguments);
 }
-_.extend(TaggedMediaFeed.prototype, FeedBase.prototype);
+util.inherits(TaggedMediaFeed, FeedBase);
 
 module.exports = TaggedMediaFeed;
 var Media = require('../media');

--- a/client/v1/feeds/thread-items.js
+++ b/client/v1/feeds/thread-items.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 
@@ -7,12 +8,11 @@ function ThreadItemsFeed(session, threadId, limit) {
     this.limit = parseInt(limit) || null;
     FeedBase.apply(this, arguments);
 }
-_.extend(ThreadItemsFeed.prototype, FeedBase.prototype);
+util.inherits(ThreadItemsFeed, FeedBase);
 
 module.exports = ThreadItemsFeed;
 var ThreadItem = require('../thread-item');
 var Request = require('../request');
-var Thread = require('../thread');
 
 
 

--- a/client/v1/feeds/timeline-feed.js
+++ b/client/v1/feeds/timeline-feed.js
@@ -1,10 +1,11 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function TimelineFeed(session) {
     FeedBase.apply(this, arguments);
 }
-_.extend(TimelineFeed.prototype, FeedBase.prototype);
+util.inherits(TimelineFeed, FeedBase);
 
 module.exports = TimelineFeed;
 var Request = require('../request');

--- a/client/v1/feeds/user-media.js
+++ b/client/v1/feeds/user-media.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var util = require('util');
 var FeedBase = require('./feed-base');
 
 function UserMediaFeed(session, accountId, limit) {
@@ -7,7 +8,7 @@ function UserMediaFeed(session, accountId, limit) {
     this.limit = limit;
     FeedBase.apply(this, arguments);
 }
-_.extend(UserMediaFeed.prototype, FeedBase.prototype);
+util.inherits(UserMediaFeed, FeedBase);
 
 module.exports = UserMediaFeed;
 var Media = require('../media');

--- a/tests/cases/feeds/account-followers.js
+++ b/tests/cases/feeds/account-followers.js
@@ -14,7 +14,7 @@ describe("`AccountFollowers` class", function() {
 
     before(function() {
         session = require('../../run').session;
-        feed = new Client.Feed.AccountFollowers(session, '25025320', 1000);
+        feed = new Client.Feed.AccountFollowers(session, '25025320', 400);
     })
 
     it("should not be problem to get followers", function(done) {
@@ -30,7 +30,7 @@ describe("`AccountFollowers` class", function() {
         })
     })
 
-    it("should not be problem to get all followers", function(done) {
+    it("should not be problem to get all followers with limit 400", function(done) {
 
         feed.all().then(function(data) {
             _.each(data, function(account) {


### PR DESCRIPTION
As you asked
Change `_.extend` to `util.inherits`
But, in every feed module underscore already exists for class necessities, and code is more clear when use _.extend. For util we must `require('utils')` only for inherit. 
Didn't you think `_.extend` is more clear?