### PR TITLE
Add Firebase support for cookies

### DIFF
--- a/client/v1.js
+++ b/client/v1.js
@@ -8,6 +8,7 @@ InstagramV1.Device = require('./v1/device');
 InstagramV1.CookieStorage = require('./v1/cookie-storage');
 InstagramV1.CookieFileStorage = require('./v1/cookie-file-storage');
 InstagramV1.CookieMemoryStorage = require('./v1/cookie-memory-storage');
+InstagramV1.CookieFirebaseStorage = require('./v1/cookie-firebase-storage');
 InstagramV1.Exceptions = require("./v1/exceptions");
 InstagramV1.prunedJson = require('./v1/json-pruned');
 InstagramV1.Resource = require('./v1/resource');

--- a/client/v1/cookie-firebase-storage.js
+++ b/client/v1/cookie-firebase-storage.js
@@ -1,0 +1,11 @@
+var util = require("util");
+var FirebaseCookieStore = require('tough-cookie-firebasestore');
+var CookieStorage = require('./cookie-storage');
+
+
+function CookieFirebaseStorage(app, firebasePath) {
+    CookieStorage.call(this, new FirebaseCookieStore(app,firebasePath))
+}
+
+util.inherits(CookieFirebaseStorage, CookieStorage);
+module.exports = CookieFirebaseStorage;

--- a/client/v1/cookie-firebase-storage.js
+++ b/client/v1/cookie-firebase-storage.js
@@ -2,6 +2,7 @@ var util = require("util");
 var FirebaseCookieStore = require('tough-cookie-firebasestore');
 var CookieStorage = require('./cookie-storage');
 
+console.log("included firebase");
 
 function CookieFirebaseStorage(app, firebasePath) {
     CookieStorage.call(this, new FirebaseCookieStore(app,firebasePath))

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -62,7 +62,7 @@ Media.prototype.parseParams = function (json) {
     }
     if (_.isObject(json.caption))
         hash.caption = json.caption.text;
-    hash.takenAt = parseInt(json.taken_at) * 1000;
+    hash.takenAt = parseInt(json.taken_at) * 1000;
     if (_.isObject(json.image_versions2))
         hash.images = json.image_versions2.candidates;
     if (_.isArray(json.video_versions))
@@ -172,85 +172,42 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
     if(!width) width = 800;
     if(!height) height = 800;
     const CROP = 1;
-    return session.getAccountId()
+    session.getAccountId()
         .then(function(accountId){
-            var payload = pruned({
-                source_type: "4",
-                caption: caption,
-                upload_id: uploadId,
-                _uid: accountId.toString(),
-                device: session.device.payload,
-                edits: {
-                    crop_original_size:["$width","$height"],
-                    crop_center: ["$zero","$negativeZero"],
-                    crop_zoom: "$crop"
-                },
-                extra: {
-                    source_width: width,
-                    source_height: height
-                }
-            });
-            payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
-            payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
-            payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
-            payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
-            payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
+        var payload = pruned({
+            source_type: "4",
+            caption: caption,
+            upload_id: uploadId,
+            _uid:accountId.toString(),
+            device: session.device.payload,
+            edits: {
+                crop_original_size:["$width","$height"],
+                crop_center: ["$zero","$negativeZero"],
+                crop_zoom: "$crop"
+            },
+            extra: {
+                source_width: width,
+                source_height: height
+            }
+        });
+        payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
+        payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
+        payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
+        payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
+        payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
 
-            return new Request(session)
-                .setMethod('POST')
-                .setResource('mediaConfigure')
-                .setBodyType('form')
-                .setData(JSON.parse(payload))
-                .generateUUID()
-                .signPayload()
-                .send()
-        })
-        .then(function(json) {
-            return new Media(session, json.media)
-        })
-};
-
-Media.configurePhotoStory = function (session, uploadId, width, height) {
-    if(_.isEmpty(uploadId))
-        throw new Error("Upload argument must be upload valid upload id");
-    if(!width) width = 800;
-    if(!height) height = 800;
-    const CROP = 1;
-    return session.getAccountId()
-        .then(function(accountId){
-            var payload = pruned({
-                source_type: "4",
-                upload_id: uploadId,
-                _uid: accountId.toString(),
-                device: session.device.payload,
-                edits: {
-                    crop_original_size:["$width","$height"],
-                    crop_center: ["$zero","$negativeZero"],
-                    crop_zoom: "$crop"
-                },
-                extra: {
-                    source_width: width,
-                    source_height: height
-                }
-            });
-            payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
-            payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
-            payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
-            payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
-            payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
-
-            return new Request(session)
-                .setMethod('POST')
-                .setResource('mediaConfigureStory')
-                .setBodyType('form')
-                .setData(JSON.parse(payload))
-                .generateUUID()
-                .signPayload()
-                .send()
-        })
-        .then(function(json) {
-            return new Media(session, json.media)
-        })
+        return new Request(session)
+            .setMethod('POST')
+            .setResource('mediaConfigure')
+            .setBodyType('form')
+            .setData(JSON.parse(payload))
+            .generateUUID()
+            .signPayload()
+            .send()
+            .then(function(json) {
+                return new Media(session, json.media)
+            })
+    })
 };
 
 Media.configureVideo = function (session, uploadId, caption, durationms, delay) {

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -62,7 +62,7 @@ Media.prototype.parseParams = function (json) {
     }
     if (_.isObject(json.caption))
         hash.caption = json.caption.text;
-    hash.takenAt = parseInt(json.taken_at) * 1000;
+    hash.takenAt = parseInt(json.taken_at) * 1000;
     if (_.isObject(json.image_versions2))
         hash.images = json.image_versions2.candidates;
     if (_.isArray(json.video_versions))

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -172,7 +172,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
     if(!width) width = 800;
     if(!height) height = 800;
     const CROP = 1;
-    session.getAccountId()
+    return session.getAccountId()
         .then(function(accountId){
         var payload = pruned({
             source_type: "4",
@@ -205,7 +205,6 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
             .signPayload()
             .send()
             .then(function(json) {
-            console.log(json);
                 return new Media(session, json.media)
             })
     })

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -205,9 +205,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
             .signPayload()
             .send()
             .then(function(json) {
-                console.log(json);
                 var media = new Media(session, json.media);
-                console.log(media);
                 return media;
             })
     })

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -206,7 +206,9 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
             .send()
             .then(function(json) {
                 console.log(json);
-                return new Media(session, json.media)
+                var media = new Media(session, json.media);
+                console.log(media);
+                return media;
             })
     })
 };

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -205,6 +205,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
             .signPayload()
             .send()
             .then(function(json) {
+                console.log(json);
                 return new Media(session, json.media)
             })
     })

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -62,7 +62,7 @@ Media.prototype.parseParams = function (json) {
     }
     if (_.isObject(json.caption))
         hash.caption = json.caption.text;
-    hash.takenAt = parseInt(json.taken_at) * 1000;
+    hash.takenAt = parseInt(json.taken_at) * 1000;
     if (_.isObject(json.image_versions2))
         hash.images = json.image_versions2.candidates;
     if (_.isArray(json.video_versions))
@@ -174,41 +174,83 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
     const CROP = 1;
     return session.getAccountId()
         .then(function(accountId){
-        var payload = pruned({
-            source_type: "4",
-            caption: caption,
-            upload_id: uploadId,
-            _uid:accountId.toString(),
-            device: session.device.payload,
-            edits: {
-                crop_original_size:["$width","$height"],
-                crop_center: ["$zero","$negativeZero"],
-                crop_zoom: "$crop"
-            },
-            extra: {
-                source_width: width,
-                source_height: height
-            }
-        });
-        payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
-        payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
-        payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
-        payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
-        payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
+            var payload = pruned({
+                source_type: "4",
+                caption: caption,
+                upload_id: uploadId,
+                _uid: accountId.toString(),
+                device: session.device.payload,
+                edits: {
+                    crop_original_size:["$width","$height"],
+                    crop_center: ["$zero","$negativeZero"],
+                    crop_zoom: "$crop"
+                },
+                extra: {
+                    source_width: width,
+                    source_height: height
+                }
+            });
+            payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
+            payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
+            payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
+            payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
+            payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
 
-        return new Request(session)
-            .setMethod('POST')
-            .setResource('mediaConfigure')
-            .setBodyType('form')
-            .setData(JSON.parse(payload))
-            .generateUUID()
-            .signPayload()
-            .send()
-            .then(function(json) {
-                var media = new Media(session, json.media);
-                return media;
-            })
-    })
+            return new Request(session)
+                .setMethod('POST')
+                .setResource('mediaConfigure')
+                .setBodyType('form')
+                .setData(JSON.parse(payload))
+                .generateUUID()
+                .signPayload()
+                .send()
+        })
+        .then(function(json) {
+            return new Media(session, json.media)
+        })
+};
+
+Media.configurePhotoStory = function (session, uploadId, width, height) {
+    if(_.isEmpty(uploadId))
+        throw new Error("Upload argument must be upload valid upload id");
+    if(!width) width = 800;
+    if(!height) height = 800;
+    const CROP = 1;
+    return session.getAccountId()
+        .then(function(accountId){
+            var payload = pruned({
+                source_type: "4",
+                upload_id: uploadId,
+                _uid: accountId.toString(),
+                device: session.device.payload,
+                edits: {
+                    crop_original_size:["$width","$height"],
+                    crop_center: ["$zero","$negativeZero"],
+                    crop_zoom: "$crop"
+                },
+                extra: {
+                    source_width: width,
+                    source_height: height
+                }
+            });
+            payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
+            payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
+            payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));
+            payload = payload.replace(/\"\$negativeZero\"/gi, "-" + (0).toFixed(1));
+            payload = payload.replace(/\"\$crop\"/gi, CROP.toFixed(1));
+
+            return new Request(session)
+                .setMethod('POST')
+                .setResource('mediaConfigureStory')
+                .setBodyType('form')
+                .setData(JSON.parse(payload))
+                .generateUUID()
+                .signPayload()
+                .send()
+        })
+        .then(function(json) {
+            return new Media(session, json.media)
+        })
 };
 
 Media.configureVideo = function (session, uploadId, caption, durationms, delay) {

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -205,6 +205,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height) {
             .signPayload()
             .send()
             .then(function(json) {
+            console.log(json);
                 return new Media(session, json.media)
             })
     })

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "touch": "^1.0.0",
     "tough-cookie": "^2.3.1",
     "tough-cookie-filestore": "0.0.1",
+    "tough-cookie-firebasestore" : "0.0.2",
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
     "socks5-https-client": "^1.1.3"


### PR DESCRIPTION
Hi, I'm using this on my fork and thought it might be of use to everyone - this uses https://firebase.google.com to provide free persistent database storage that can be shared between instagram servers. To use, first create a firebase project on the website and download a service account file, then initialise the App like this 

var app = firebase.initializeApp({ ... }); // Use object as described here https://firebase.google.com/docs/database/admin/start

Once this is done, use the cookie storage as normal, providing a database location for cookie storage as the second variable:

var storage = new Client.CookieFirebaseStorage(app, "/instagram/cookies/" + username);

*** Note I couldn't get it to realise I hadn't made any changes to media.js, hope this doesn't cause issues. Let me know if you need a new pull request