### PR TITLE
Add missing carousel images

### DIFF
--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -64,8 +64,13 @@ Media.prototype.parseParams = function (json) {
     if (_.isObject(json.caption))
         hash.caption = json.caption.text;
     hash.takenAt = parseInt(json.taken_at) * 1000;
-    if (_.isObject(json.image_versions2))
+    if (_.isObject(json.image_versions2)) {
         hash.images = json.image_versions2.candidates;
+    } else if (_.isObject(json.carousel_media)) {
+        hash.images = json.carousel_media.map(function(media) {
+            return media.image_versions2.candidates
+        })
+    }
     if (_.isArray(json.video_versions))
         hash.videos = json.video_versions;
     this.previewComments = _.map(json.preview_comments, function(comment) {


### PR DESCRIPTION
I'm not sure this is ideal solution, but currently `images` field is missing for all `Media` type items which have carousel images (and users are using the feature more and more). So I thought it's much better to have something working rather than having nothing... :)