### PR TITLE
Return carousel items for albums

### DIFF
--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -63,7 +63,7 @@ Media.prototype.parseParams = function (json) {
             duration: json.video_duration
         }
     }
-    if (json.media_type === 8) {
+    if (json.media_type === 8 && _.isArray(json.carousel_media)) { 
         hash.carouselMedia = _.map(json.carousel_media, function (medium) {
            return new Media(that.session, medium);
         });

--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -39,6 +39,7 @@ Media.prototype.parseParams = function (json) {
     hash.deviceTimestamp = json.device_timestamp;
     hash.webLink = "https://www.instagram.com/p/" + json.code + "/"
     hash.usertags = json.usertags;
+    hash.carouselMedia = [];
 
     if(json.video_duration)
         hash.videoDuration = json.video_duration;
@@ -61,6 +62,11 @@ Media.prototype.parseParams = function (json) {
             hasAudio: json.has_audio,
             duration: json.video_duration
         }
+    }
+    if (json.media_type === 8) {
+        hash.carouselMedia = _.map(json.carousel_media, function (medium) {
+           return new Media(that.session, medium);
+        });
     }
     if (_.isObject(json.caption))
         hash.caption = json.caption.text;


### PR DESCRIPTION
Currently, items in an album are not returned in the feed, this small tweak fixes that. Album items are accessible from the carouselMedia property.