### PR TITLE
add isVerified field to account properties

### DIFF
--- a/client/v1/account.js
+++ b/client/v1/account.js
@@ -32,6 +32,7 @@ Account.prototype.parseParams = function (json) {
     hash.isPrivate = json.is_private;
     hash.hasAnonymousProfilePicture = json.has_anonymous_profile_picture;
     hash.isBusiness = !!json.is_business;
+    hash.isVerified = !!json.is_verified;
     if(_.isString(json.profile_pic_id))
         hash.profilePicId = json.profile_pic_id;
     if(_.isString(json.byline))


### PR DESCRIPTION
For some use cases, we need to know whether an account is verified or not. So adding `isVerified` field to the account properties would be useful.