### PR TITLE
Change `Helpers.isValidUrl` to external library `valid-url`.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require("path");
 var touch = require("touch");
 var isStream = require("is-stream");
+var validUrl = require('valid-url');
 var _ = require("underscore");
 
 var emailTester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-?\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
@@ -38,10 +39,7 @@ Helpers.buildRankToken = function (accountId) {
 };
 
 
-Helpers.isValidUrl = function(textval) {
-    var urlregex = /^(https?|ftp):\/\/([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)*((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}|([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.(com|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|[a-zA-Z]{2}))(:[0-9]+)*(\/($|[a-zA-Z0-9.,?'\\+&%$#=~_-]+))*$/;
-    return urlregex.test(textval);
-}
+Helpers.isValidUrl = validUrl.isUri;
 
 
 Helpers.ensureExistenceOfJSONFilePath = function(path) {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "node-cache": "^3.0.0",
     "request": "^2.64.0",
     "request-promise": "^1.0.2",
+    "socks5-https-client": "^1.1.3",
     "touch": "^1.0.0",
     "tough-cookie": "^2.3.1",
     "tough-cookie-filestore": "0.0.1",
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
-    "socks5-https-client": "^1.1.3"
+    "valid-url": "1.0.9"
   },
   "devDependencies": {
     "faker": "^3.1.0",


### PR DESCRIPTION
Because `http:127.0.0.1` is a valid URL. And official nodejs lib `url` in `url.format()` method generates such urls, without slashes.
I suggest not to reinvent the wheel again and use third-party library to determine a valid url.

P.S.
And `http://username:login@127.0.0.1` is a valid URL too. And, i think, much more cases, which were not considered in old method
