### PR TITLE
Improves

### DIFF
--- a/client/v1/feeds/account-followers.js
+++ b/client/v1/feeds/account-followers.js
@@ -4,8 +4,7 @@ var FeedBase = require('./feed-base');
 
 function AccountFollowersFeed(session, accountId, limit) {
     this.accountId = accountId;
-    this.limit = limit || 7500;
-    // Should be enought for 7500 records
+    this.limit = limit || Infinity;
     this.timeout = 10 * 60 * 1000;
     FeedBase.apply(this, arguments);
 }

--- a/client/v1/feeds/feed-base.js
+++ b/client/v1/feeds/feed-base.js
@@ -71,8 +71,13 @@ FeedBase.prototype.isMoreAvailable = function() {
     return !!this.moreAvailable;
 };
 
-FeedBase.prototype.allSafe = function (parameters) {
-    return this.all(parameters).timeout(this.timeout);
+FeedBase.prototype.allSafe = function (parameters, timeout) {
+    var that = this;
+    return this.all(parameters).timeout(timeout || this.timeout)
+        .catch(Promise.TimeoutError, function (reason) {
+            that.stop();
+            throw reason;
+        })
 };
 
 module.exports = FeedBase;


### PR DESCRIPTION
1) Improve `.allSafe()`. Now user can define his own timeout. And when timed out, collecting stops.

2) Remove unobvious default limit for followers. Because why not 8000? 8500? 9000? Especially when i call .all() without limit, i want to get all, not 7500.