### PR TITLE
Modified Url extract

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -118,7 +118,7 @@ Helpers.dataToRequestOption = function (data, filename) {
 }
 
 Helpers.extractUrl = function (text) {
-  return text.match(/[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/g);
+  return text.match(/((?:https\:\/\/)|(?:http\:\/\/)|(?:www\.))?([a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(?:\??)[a-zA-Z0-9\-\._\?\,\'\/\\\+&%\$#\=~]+)/g);
 }
 
 module.exports = Helpers;


### PR DESCRIPTION
in Clickable text, Url extract logic changed.

examples
1. http://regexr.com/foo.html?q=bar
2. powerhttp://www.google.com
3. www.demo.com

## before
1. http://regexr.com/foo.html
2. powerhttp://www.google.com
3. www.demo.com

## after(this commit)
1. http://regexr.com/foo.html?q=bar (include params)
2. http://www.google.com
3. www.demo.com