### PR TITLE
Fixed media circular structure error

### DIFF
--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -30,7 +30,7 @@ Media.prototype.parseParams = function (json) {
     hash.webLink = "https://www.instagram.com/p/" + json.code + "/";
     hash.carouselMedia = [];
     if(_.isObject(json.location)) {
-        var location = json.location;
+        var location = _.clone(json.location);
         location.location = Object.create(json.location);
         location.title = location.name;
         location.subtitle = null;


### PR DESCRIPTION
Media objects have circular reference (location property), and error is occured if they are directly returned as json response. With simple clone method using lodash this can be very easily avoided, and it's very useful. Single line. Please merge ASAP.