### PR TITLE
fix issue with setting cookies for wrong domain

### DIFF
--- a/client/v1/jar.js
+++ b/client/v1/jar.js
@@ -22,7 +22,7 @@ RequestJar.prototype.rewriteUri = function(uri) {
 RequestJar.prototype.setCookie = function(cookieOrStr, uri, options) {
     var self = this;
     uri = this.rewriteUri(uri);
-    // remove domain from cookie strign so domain from uri will be used
+    // remove domain from cookie string so domain from uri will be used
     cookieOrStr = cookieOrStr.replace(/Domain=(.*?); /g, '');
     return self._jar.setCookieSync(cookieOrStr, uri, options || {});
 };

--- a/client/v1/jar.js
+++ b/client/v1/jar.js
@@ -22,6 +22,8 @@ RequestJar.prototype.rewriteUri = function(uri) {
 RequestJar.prototype.setCookie = function(cookieOrStr, uri, options) {
     var self = this;
     uri = this.rewriteUri(uri);
+    // remove domain from cookie strign so domain from uri will be used
+    cookieOrStr = cookieOrStr.replace(/Domain=(.*?); /g, '');
     return self._jar.setCookieSync(cookieOrStr, uri, options || {});
 };
 


### PR DESCRIPTION
I had a problem with cookies being set for instagram.com instead of i.instagram.com, this line fixes the issue.