### PR TITLE
fix setCookie method of jar wrapper to handle tough.Cookie instance

### DIFF
--- a/client/v1/jar.js
+++ b/client/v1/jar.js
@@ -22,8 +22,12 @@ RequestJar.prototype.rewriteUri = function(uri) {
 RequestJar.prototype.setCookie = function(cookieOrStr, uri, options) {
     var self = this;
     uri = this.rewriteUri(uri);
-    // remove domain from cookie string so domain from uri will be used
-    cookieOrStr = cookieOrStr.replace(/Domain=(.*?); /g, '');
+    // remove domain from cookie so domain from uri will be used
+    if (cookieOrStr instanceof tough.Cookie) {
+        cookieOrStr.domain = null;
+    } else {
+        cookieOrStr = cookieOrStr.replace(/Domain=(.*?); /g, '');
+    }
     return self._jar.setCookieSync(cookieOrStr, uri, options || {});
 };
 


### PR DESCRIPTION
It's not necessary in our case but cookieOrStr argument can be both string and tough.Cookie instance so it's right to handle both cases.