### PR TITLE
Updated support for getAllCookies

### DIFF
--- a/client/v1/cookie-file-storage.js
+++ b/client/v1/cookie-file-storage.js
@@ -5,17 +5,25 @@ var fs = require('fs');
 var _ = require('lodash');
 var Helpers = require('../../helpers');
 var CookieStorage = require('./cookie-storage');
-
+var CONSTANTS = require("./constants");
 
 function CookieFileStorage(cookiePath) {
     cookiePath = path.resolve(cookiePath);
     Helpers.ensureExistenceOfJSONFilePath(cookiePath);
-    CookieStorage.call(this, new FileCookieStore(cookiePath))
+    var store = new FileCookieStore(cookiePath);
+    store.__proto__.getAllCookies = function (cb) {
+      store.findCookies(CONSTANTS.HOSTNAME, '/', function (err, cookies) {
+        cookies.sort(function (a, b) {
+          return (a.creationIndex || 0) - (b.creationIndex || 0);
+        });
+        cb(null, cookies);
+      });
+    }
+    CookieStorage.call(this, store);
 }
 
 util.inherits(CookieFileStorage, CookieStorage);
 module.exports = CookieFileStorage;
-
 
 CookieFileStorage.prototype.destroy = function(){
     fs.unlinkSync(this.storage.filePath);


### PR DESCRIPTION
**_The following is not my code._**
This pull request was amended from an [earlier request](https://github.com/huttarichard/instagram-private-api/pull/123) by [crobject](https://github.com/crobject). The only part that was changed was the package 'underscore' that is now 'lodash'.

Purpose: Implement getAllCookies so that object can be serialized and res.json (implementation in Express) will work well. Right now I have to manually change this file in node_modules. I only made another pull request because the other one was closed.

Thank you!