### PR TITLE
Added support for accessing story tray response

### DIFF
--- a/client/v1/feeds/story-tray.js
+++ b/client/v1/feeds/story-tray.js
@@ -16,7 +16,7 @@ StoryTray.prototype.get = function () {
         .setResource('storyTray')
         .send()
         .then(function(data) {
-            var media = _.map(data.items, function(medium){
+            var media = _.map(data.tray, function(medium){
                 return new Media(that.session, medium);
             });
             return media;    


### PR DESCRIPTION
`data` on line 18 contains `broadcasts` and `tray` instead of items now.

Just out of curiosity, is `broadcasts` a way to implement the request #104?