### PR TITLE
Add UserTagsMedia feed to get user tags media

### DIFF
--- a/client/v1.js
+++ b/client/v1.js
@@ -47,6 +47,7 @@ InstagramV1.Feed.TagMedia = InstagramV1.Feed.TaggedMedia; // Alias but deprecate
 InstagramV1.Feed.ThreadItems = require('./v1/feeds/thread-items');
 InstagramV1.Feed.Timeline = require('./v1/feeds/timeline-feed');
 InstagramV1.Feed.UserMedia = require('./v1/feeds/user-media');
+InstagramV1.Feed.UserTagsMedia = require('./v1/feeds/user-tags-media');
 InstagramV1.Feed.SelfLiked = require('./v1/feeds/self-liked');
 InstagramV1.Feed.MediaComments = require('./v1/feeds/media-comments');
 InstagramV1.Feed.SavedMedia = require('./v1/feeds/saved-media');

--- a/client/v1/constants.js
+++ b/client/v1/constants.js
@@ -31,6 +31,7 @@ const ROUTES = {
     friendshipPendingApprove: 'friendships/approve/<%= id %>/',
     userInfo: 'users/<%= id %>/info/',
     userFeed: 'feed/user/<%= id %>/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>rank_token=<%= rankToken %>',
+    userTagsFeed: 'usertags/<%= id %>/feed/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>',
     timelineFeed: 'feed/timeline/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>rank_token=<%= rankToken %>&ranked_content=true',
     tagFeed: 'feed/tag/<%= encodeURI(tag) %>/?<%= maxId ? ("max_id=" + maxId + "&") : "" %>rank_token=<%= rankToken %>',
     selfLikedFeed: 'feed/liked/<%= maxId ? ("?max_id=" + maxId) : "" %>',

--- a/client/v1/feeds/user-tags-media.js
+++ b/client/v1/feeds/user-tags-media.js
@@ -26,10 +26,9 @@ UserTagsMediaFeed.prototype.get = function () {
                 })
                 .send()
                 .then(function(data) {
-                    that.moreAvailable = data.more_available;
-                    var lastOne = _.last(data.items);
-                    if (that.moreAvailable && lastOne) {
-                        that.setCursor(lastOne.id);
+                    that.moreAvailable = !!data.next_max_id;
+                    if (that.moreAvailable) {
+                        that.setCursor(data.next_max_id);
                     }
                     return _.map(data.items, function (medium) {
                         return new Media(that.session, medium);

--- a/client/v1/feeds/user-tags-media.js
+++ b/client/v1/feeds/user-tags-media.js
@@ -1,0 +1,39 @@
+var _ = require('lodash');
+var util = require('util');
+var FeedBase = require('./feed-base');
+
+function UserTagsMediaFeed(session, accountId, limit) {
+    this.accountId = accountId;
+    this.timeout = 10 * 60 * 1000; // 10 minutes
+    this.limit = limit;
+    FeedBase.apply(this, arguments);
+}
+util.inherits(UserTagsMediaFeed, FeedBase);
+
+module.exports = UserTagsMediaFeed;
+var Media = require('../media');
+var Request = require('../request');
+
+UserTagsMediaFeed.prototype.get = function () {
+    var that = this;
+    return this.session.getAccountId()
+        .then(function() {
+            return new Request(that.session)
+                .setMethod('GET')
+                .setResource('userTagsFeed', {
+                    id: that.accountId,
+                    maxId: that.getCursor()
+                })
+                .send()
+                .then(function(data) {
+                    that.moreAvailable = data.more_available;
+                    var lastOne = _.last(data.items);
+                    if (that.moreAvailable && lastOne) {
+                        that.setCursor(lastOne.id);
+                    }
+                    return _.map(data.items, function (medium) {
+                        return new Media(that.session, medium);
+                    });
+                })
+        });
+};

--- a/tests/cases/feeds/user-tags-media.js
+++ b/tests/cases/feeds/user-tags-media.js
@@ -1,0 +1,27 @@
+var should = require('should');
+var Client = require('../../../client/v1');
+var _ = require('lodash');
+
+describe('`UserTagsMedia` class', function() {
+    var feed, session;
+
+    before(function() {
+        // https://github.com/huttarichard/instagram-private-api/issues/23
+        session = require('../../run').session;
+        feed = new Client.Feed.UserTagsMedia(session, 25025320);
+    })
+
+    it('should not be problem to get user tags media', function(done) {
+        var originalCursor = feed.getCursor();
+        feed.get().then(function(media) {
+            media.length.should.be.above(0);
+            _.each(media, function(medium) {
+                medium.should.be.instanceOf(Client.Media);
+            });
+            should(originalCursor).should.not.equal(feed.getCursor());
+            feed.moreAvailable.should.be.Boolean();
+            feed.moreAvailable.should.equal(true);
+            done();
+        });
+    });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -87,7 +87,7 @@ describe("Sessions", function () {
                 .then(function(account) {
                     account.params.username.should.be.equal('instagram');
                     done();
-                }) 
+                })
         })
 
         it("should not be problem to show discover feed", function(done) {
@@ -97,7 +97,7 @@ describe("Sessions", function () {
                     discover[0].account.should.be.instanceOf(Client.Account)
                     discover[0].mediaIds.should.be.Array();
                     done();
-                }) 
+                })
         })
 
         it("should be able to ask for json endpoint trough web-request", function(done) {
@@ -111,13 +111,13 @@ describe("Sessions", function () {
                     result.user.username.should.be.String();
                     result.user.username.should.equal('instagram')
                     done();
-                }) 
+                })
         })
 
         it("should not be problem to get media likers", function(done) {
             Client.Media.likers(session, '1317759032287303554_25025320')
                 .then(function(likers) {
-                    _.each(likers, function(liker){ 
+                    _.each(likers, function(liker){
                         liker.should.be.instanceOf(Client.Account)
                     })
                     done();
@@ -251,5 +251,6 @@ describe("Sessions", function () {
         require('./cases/feeds/timeline');
         require('./cases/feeds/account-following');
         require('./cases/feeds/account-followers');
-    })
-})
+        require('./cases/feeds/user-tags-media');
+    });
+});


### PR DESCRIPTION
A new feed to get the media that has been tagged with a certain user id.

Instagram documentation: https://help.instagram.com/167099750119914?helpref=uf_permalink

> To see photos other people have tagged you in, go to your profile and tap <img width="22" alt="screen shot 2018-07-06 at 13 56 35" src="https://user-images.githubusercontent.com/1935696/42377669-80bfe32e-8124-11e8-9630-1bfd5661d4c3.png">

I modeled the request off of the request made in [the `getUserFeed` method in mgp25/Instagram-API](https://github.com/mgp25/Instagram-API/blob/a640aae361cb895c64234d453b416e5044c33ae7/src/Request/Usertag.php#L87-L108)