### PR TITLE
Removed dot on line 69 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You need to obtain a session to access endpoints with the `Session` class:
 ```javascript
 var Client = require('instagram-private-api').V1;
 var device = new Client.Device('someuser');
-var storage = new Client.CookieFileStorage(__dirname + './cookies/someuser.json');
+var storage = new Client.CookieFileStorage(__dirname + '/cookies/someuser.json');
 
 // And go for login
 Client.Session.create(device, storage, 'someuser', 'somepassword')


### PR DESCRIPTION
The way it is currently is incorrect. You either have to say __dirname + '/cookies.someuser.json' or './cookies.someuser.json'. You cannot do both, because that is trying to get the working directory both times, and it doesn't work. Proposed change for more clarity