### PR TITLE
Added support for reel_mentions and story_polls

### DIFF
--- a/client/v1/media.js
+++ b/client/v1/media.js
@@ -212,7 +212,7 @@ Media.configurePhoto = function (session, uploadId, caption, width, height, user
         })
 };
 
-Media.configurePhotoStory = function (session, uploadId, width, height) {
+Media.configurePhotoStory = function (session, uploadId, width, height, storyMentions = [], storyPoll = {}) {
     if(_.isEmpty(uploadId))
         throw new Error("Upload argument must be upload valid upload id");
     if(!width) width = 800;
@@ -222,6 +222,8 @@ Media.configurePhotoStory = function (session, uploadId, width, height) {
         .then(function(accountId){
             var payload = pruned({
                 source_type: "4",
+                reel_mentions: JSON.stringify(storyMentions),
+                story_polls: JSON.stringify([storyPoll]),
                 upload_id: uploadId,
                 _uid: accountId.toString(),
                 device: session.device.payload,
@@ -235,6 +237,7 @@ Media.configurePhotoStory = function (session, uploadId, width, height) {
                     source_height: height
                 }
             });
+
             payload = payload.replace(/\"\$width\"/gi, width.toFixed(1));
             payload = payload.replace(/\"\$height\"/gi, height.toFixed(1));
             payload = payload.replace(/\"\$zero\"/gi, (0).toFixed(1));


### PR DESCRIPTION
This enables support for reel_mentions (tags in stories) and story polls.

Example:
```javascript
let reelMentions = [
  {
    user_id: '123456789', // Must be a numerical UserPK ID.
    x: 0.5, // Range: 0.0 - 1.0. Note that x = 0.5 and y = 0.5 is center of screen.
    y: 0.5, // Also note that X/Y is setting the position of the CENTER of the clickable area.
    width: 1, // Clickable area size, as percentage of image size: 0.0 - 1.0
    height: 1, // ...
    rotation: 0.0,
    is_sticker: true // Don't change this value.
  }
]

let storyPoll = {
  question: 'Does it work?', // Story poll question. You need to manually to draw it on top of your image.
  viewer_vote: 0, // Don't change this value.
  viewer_can_vote: true, // Don't change this value.
  tallies: [
    {
      text: 'Yes! :)', // Answer 1.
      count: 0, // Don't change this value.
      font_size: 35 // Range: 17.5 - 35.0.
    },
    {
      text: 'No! :(', // Answer 2.
      count: 0, // Don't change this value.
      font_size: 35 // Range: 17.5 - 35.0.
    }
  ],
  x: 0.5, // Range: 0.0 - 1.0. Note that x = 0.5 and y = 0.5 is center of screen.
  y: 0.5, // Also note that X/Y is setting the position of the CENTER of the clickable area.
  width: 0.5, // Clickable area size, as percentage of image size: 0.0 - 1.0
  height: 0.1, // ...
  rotation: 0.0,
  is_sticker: true // Don't change this value.
}

Client.Media.configurePhotoStory(session, uploadId, undefined, undefined, reelMentions, storyPoll).then(...)
```