### PR TITLE
session.setProxy supports SOCKS

### DIFF
--- a/client/v1/request.js
+++ b/client/v1/request.js
@@ -64,12 +64,16 @@ Request.setProxy = function (proxyUrl) {
     Request.requestClient = request.defaults(object);
 }
 
-Request.setSocks5Proxy = function (host, port) {
-    var object = { agentClass: Agent,
-    agentOptions: {
-        socksHost: host, // Defaults to 'localhost'.
-        socksPort: port // Defaults to 1080.
-    }};
+Request.setSocks5Proxy = function (host, port, username, password) {
+    var object = {
+        agentClass: Agent,
+        agentOptions: {
+            socksHost: host, // Defaults to 'localhost'.
+            socksPort: port, // Defaults to 1080.
+            socksUsername: (username) ? username : null,
+            socksPassword: (password) ? password : null
+        }
+    };
     Request.requestClient = request.defaults(object);
 }
 
@@ -227,8 +231,24 @@ Request.prototype.setSession = function(session) {
     });
     if(session.device)
         this.setDevice(session.device);
-    if(session.proxyUrl)
-        this.setOptions({proxy: session.proxyUrl});
+    if(session.proxyUrl) {
+        var proxyObject = Helpers.getProxyObject(session.proxyUrl);
+
+        if(proxyObject.http) {
+            this.setOptions({proxy: proxyObject.http});
+        } else if(proxyObject.socks) {
+            this.setOptions({
+                agentClass: Agent,
+                agentOptions: {
+                    socksHost: proxyObject.socks.host,
+                    socksPort: proxyObject.socks.port,
+                    socksUsername: proxyObject.socks.username,
+                    socksPassword: proxyObject.socks.password
+                }
+            });
+        }
+
+    }
     return this;
 };
 

--- a/helpers.js
+++ b/helpers.js
@@ -121,4 +121,28 @@ Helpers.extractUrl = function (text) {
   return text.match(/((?:https\:\/\/)|(?:http\:\/\/)|(?:www\.))?([a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(?:\??)[a-zA-Z0-9\-\._\?\,\'\/\\\+&%\$#\=~]+)/g);
 }
 
+Helpers.getProxyObject = function (str) {
+    var obj = {
+        http: null,
+        socks: null
+    };
+
+    if(/^http/.test(str)) {
+        obj.http = str;
+    } else if(/^socks/.test(str)) {
+        const parts = _.trim(str).match(/^socks:\/\/((.*?):(.*?)@)*(.*?):(\d+)$/);
+
+        if(parts && parts[4] && parts[5]) {
+            obj.socks = {
+                host: parts[4],
+                port: parts[5],
+                username: parts[2] || null,
+                password: parts[3] || null
+            }
+        }
+    }
+
+    return obj;
+}
+
 module.exports = Helpers;


### PR DESCRIPTION
Example:
`session.setProxy('socks://username:password@domain:port');`
`session.setProxy('socks://domain:port');`
