### PR TITLE
Relax engines requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "8.0.0"
+    "node": ">=8.0.0"
   },
   "bugs": {
     "url": "https://github.com/huttarichard/instagram-private-api/issues",


### PR DESCRIPTION
When installing the package from master or a recent tag, it fails in yarn if the current running node version is anything by 8.0.0 (even 8.0.1 will fail).

Unless we have strict reasoning, we should state that it supports all versions up from 8 until we have reason to believe there are incompatibilities with newer versions.