### PR TITLE
undo remove header x-csrftoken

### DIFF
--- a/src/v1/web/challenge.js
+++ b/src/v1/web/challenge.js
@@ -202,7 +202,6 @@ class Challenge {
       .setData({
         security_code: code,
       })
-      .removeHeader('x-csrftoken')
       .send({ followRedirect: false })
       .then(response => {
         let json;


### PR DESCRIPTION
If send challenge code without header `x-csrftoken` we get an error:

![without_header](https://user-images.githubusercontent.com/14164017/52525097-547db680-2cad-11e9-8e95-08e868285b24.jpg)

With `x-csrftoken` header all is fine:

![with_header](https://user-images.githubusercontent.com/14164017/52525116-9dce0600-2cad-11e9-9a04-b132af55fc1f.jpg)
