### PR TITLE
Feature pending friendships

### DIFF
--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -2,7 +2,7 @@ import { IgApiClient } from './client';
 import {
   AccountFollowersFeed,
   AccountFollowingFeed,
-  AccountFriendshipsFeed,
+  PendingFriendshipsFeed,
   DirectInboxFeed,
   DirectThreadFeed,
   LocationFeed,
@@ -30,9 +30,8 @@ export class FeedFactory {
     feed.id = id || this.client.state.cookieUserId;
     return feed;
   }
-  public accountPendingFriendships(id?: string | number): AccountFriendshipsFeed {
-    const feed = new AccountFriendshipsFeed(this.client);
-    feed.id = id || this.client.state.cookieUserId;
+  public pendingFriendships(): PendingFriendshipsFeed {
+    const feed = new PendingFriendshipsFeed(this.client);
     return feed;
   }
   public directInbox(): DirectInboxFeed {

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -2,6 +2,7 @@ import { IgApiClient } from './client';
 import {
   AccountFollowersFeed,
   AccountFollowingFeed,
+  AccountFriendshipsFeed,
   DirectInboxFeed,
   DirectThreadFeed,
   LocationFeed,
@@ -26,6 +27,11 @@ export class FeedFactory {
   }
   public accountFollowing(id?: string | number): AccountFollowingFeed {
     const feed = new AccountFollowingFeed(this.client);
+    feed.id = id || this.client.state.cookieUserId;
+    return feed;
+  }
+  public accountPendingFriendships(id?: string | number): AccountFriendshipsFeed {
+    const feed = new AccountFriendshipsFeed(this.client);
     feed.id = id || this.client.state.cookieUserId;
     return feed;
   }

--- a/src/feeds/account-friendships.feed.ts
+++ b/src/feeds/account-friendships.feed.ts
@@ -1,22 +1,21 @@
 import { Expose, plainToClassFromExist } from 'class-transformer';
 import { Feed } from '../core/feed';
-import { AccountFriendshipsFeedResponse, AccountFriendshipsFeedResponseUsersItem } from '../responses';
+import { PendingFriendshipsFeedResponse, PendingFriendshipsFeedResponseUsersItem } from '../responses';
 
-export class AccountFriendshipsFeed extends Feed<
-  AccountFriendshipsFeedResponse,
-  AccountFriendshipsFeedResponseUsersItem
+export class PendingFriendshipsFeed extends Feed<
+  PendingFriendshipsFeedResponse,
+  PendingFriendshipsFeedResponseUsersItem
 > {
-  id: number | string;
   @Expose()
   private nextMaxId: string;
 
-  set state(body: AccountFriendshipsFeedResponse) {
+  set state(body: PendingFriendshipsFeedResponse) {
     this.moreAvailable = !!body.next_max_id;
     this.nextMaxId = body.next_max_id;
   }
 
   async request() {
-    const { body } = await this.client.request.send<AccountFriendshipsFeedResponse>({
+    const { body } = await this.client.request.send<PendingFriendshipsFeedResponse>({
       url: `/api/v1/friendships/pending`,
       qs: {
         rank_token: this.rankToken,
@@ -30,7 +29,7 @@ export class AccountFriendshipsFeed extends Feed<
   async items() {
     const body = await this.request();
     return body.users.map(user =>
-      plainToClassFromExist(new AccountFriendshipsFeedResponseUsersItem(this.client), user),
+      plainToClassFromExist(new PendingFriendshipsFeedResponseUsersItem(this.client), user),
     );
   }
 }

--- a/src/feeds/account-friendships.feed.ts
+++ b/src/feeds/account-friendships.feed.ts
@@ -1,0 +1,36 @@
+import { Expose, plainToClassFromExist } from 'class-transformer';
+import { Feed } from '../core/feed';
+import { AccountFriendshipsFeedResponse, AccountFriendshipsFeedResponseUsersItem } from '../responses';
+
+export class AccountFriendshipsFeed extends Feed<
+  AccountFriendshipsFeedResponse,
+  AccountFriendshipsFeedResponseUsersItem
+> {
+  id: number | string;
+  @Expose()
+  private nextMaxId: string;
+
+  set state(body: AccountFriendshipsFeedResponse) {
+    this.moreAvailable = !!body.next_max_id;
+    this.nextMaxId = body.next_max_id;
+  }
+
+  async request() {
+    const { body } = await this.client.request.send<AccountFriendshipsFeedResponse>({
+      url: `/api/v1/friendships/pending`,
+      qs: {
+        rank_token: this.rankToken,
+        max_id: this.nextMaxId,
+      },
+    });
+    this.state = body;
+    return body;
+  }
+
+  async items() {
+    const body = await this.request();
+    return body.users.map(user =>
+      plainToClassFromExist(new AccountFriendshipsFeedResponseUsersItem(this.client), user),
+    );
+  }
+}

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -1,5 +1,6 @@
 export * from './account-followers.feed';
 export * from './account-following.feed';
+export * from './account-friendships.feed';
 export * from './direct-inbox.feed';
 export * from './direct-thread.feed';
 export * from './location.feed';

--- a/src/repositories/friendship.repository.ts
+++ b/src/repositories/friendship.repository.ts
@@ -17,6 +17,14 @@ export class FriendshipRepository extends Repository {
     return this.change('destroy', id, mediaIdAttribution);
   }
 
+  async approve(id: string | number, mediaIdAttribution?: string) {
+    return this.change('approve', id, mediaIdAttribution);
+  }
+
+  async deny(id: string | number, mediaIdAttribution?: string) {
+    return this.change('ignore', id, mediaIdAttribution);
+  }
+
   private async change(action: string, id: string | number, mediaIdAttribution?: string) {
     const { body } = await this.client.request.send<FriendshipRepositoryChangeResponseRootObject>({
       url: `/api/v1/friendships/${action}/${id}/`,

--- a/src/responses/account-friendships.feed.response.ts
+++ b/src/responses/account-friendships.feed.response.ts
@@ -1,14 +1,14 @@
 import { ProfileEntity } from '../entities/profile.entity';
 
-export interface AccountFriendshipsFeedResponse {
+export interface PendingFriendshipsFeedResponse {
   sections: null;
-  users: AccountFriendshipsFeedResponseUsersItem[];
+  users: PendingFriendshipsFeedResponseUsersItem[];
   big_list: boolean;
   next_max_id: null;
   page_size: number;
   status: string;
 }
-export class AccountFriendshipsFeedResponseUsersItem extends ProfileEntity {
+export class PendingFriendshipsFeedResponseUsersItem extends ProfileEntity {
   pk: number;
   username: string;
   full_name: string;

--- a/src/responses/account-friendships.feed.response.ts
+++ b/src/responses/account-friendships.feed.response.ts
@@ -1,0 +1,22 @@
+import { ProfileEntity } from '../entities/profile.entity';
+
+export interface AccountFriendshipsFeedResponse {
+  sections: null;
+  users: AccountFriendshipsFeedResponseUsersItem[];
+  big_list: boolean;
+  next_max_id: null;
+  page_size: number;
+  status: string;
+}
+export class AccountFriendshipsFeedResponseUsersItem extends ProfileEntity {
+  pk: number;
+  username: string;
+  full_name: string;
+  is_private: boolean;
+  profile_pic_url: string;
+  profile_pic_id?: string;
+  is_verified: boolean;
+  has_anonymous_profile_picture: boolean;
+  is_favorite: boolean;
+  latest_reel_media?: number;
+}

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -2,6 +2,7 @@ export * from './account.repository.current-user.response';
 export * from './account.repository.login.error.response';
 export * from './account.repository.login.response';
 export * from './account-followers.feed.response';
+export * from './account-friendships.feed.response';
 export * from './account-following.feed.response';
 export * from './challenge.state.response';
 export * from './checkpoint.response';

--- a/src/responses/user.repository.info.response.ts
+++ b/src/responses/user.repository.info.response.ts
@@ -64,6 +64,11 @@ export interface UserRepositoryInfoResponseUser {
   nametag: UserRepositoryInfoResponseNametag;
   auto_expand_chaining: boolean;
   highlight_reshare_disabled: boolean;
+  public_email?: string;
+  address_street?: string;
+  category?: string;
+  contact_phone_number?: string;
+  public_phone_country_code?: string;
 }
 export interface UserRepositoryInfoResponseBiography_with_entities {
   raw_text: string;


### PR DESCRIPTION
- Add pending friendships feed
- Add approve + deny pending friendships to friendship repository.

Usage:

```
const feed = ig.feed.accountPendingFriendships(loggedInUser.pk);
const items = await feed.items();
const body = await ig.friendship.approve(items[0].pk);
console.log(body);
```
Will log friendship_status:
```
{ following: true,
  followed_by: true,
  blocking: false,
  muting: false,
  is_private: true,
  incoming_request: false,
  outgoing_request: false,
  is_bestie: false,
  is_restricted: false }
```

Any changes needed please let me know and I would love to update!