### PR TITLE
(Readme) Added temporary auto generated docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ ig.state.proxyUrl = process.env.IG_PROXY;
   });
 })();
 ```
+# Documentation
+
+We have auto generated documentation as a temporary solution. This docs was generated with TypeDoc and contains all entities, methods, it can be helpful.
+
+* [Documentation main page](https://realinstadude.github.io/ipapi-docs/)
+* [Client propertries documentation](https://realinstadude.github.io/ipapi-docs/classes/_core_client_.igapiclient.html)
 
 # Contribution
 


### PR DESCRIPTION
So I've generated docs and suggest my gh-pages repo as a good temporary solution.
Until we have not any regular documentation I will support and update my repo. Is it ok?