### PR TITLE
Allows to set limit of dm threads per request

### DIFF
--- a/examples/dm-thread-pagination.example.ts
+++ b/examples/dm-thread-pagination.example.ts
@@ -4,9 +4,7 @@ import { IgApiClient } from '../src';
   const ig = new IgApiClient();
   ig.state.generateDevice(process.env.IG_USERNAME);
   await ig.account.login(process.env.IG_USERNAME, process.env.IG_PASSWORD);
-  const inboxFeed = ig.feed.directInbox();
-  //set the limit threads per request. default 20
-  inboxFeed.limit = 10;
+  const inboxFeed = ig.feed.directInbox(10);
   do {
     let threads = await inboxFeed.items();
     threads.forEach(element => {

--- a/examples/dm-thread-pagination.example.ts
+++ b/examples/dm-thread-pagination.example.ts
@@ -1,0 +1,16 @@
+import { IgApiClient } from '../src';
+
+(async () => {
+  const ig = new IgApiClient();
+  ig.state.generateDevice(process.env.IG_USERNAME);
+  await ig.account.login(process.env.IG_USERNAME, process.env.IG_PASSWORD);
+  const inboxFeed = ig.feed.directInbox();
+  //set the limit threads per request. default 20
+  inboxFeed.limit = 10;
+  do {
+    let threads = await inboxFeed.items();
+    threads.forEach(element => {
+      console.log(element['users'][0]['username']);
+    });
+  } while (inboxFeed.moreAvailable);
+})();

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -46,8 +46,10 @@ export class FeedFactory {
   public blockedUsers(): BlockedUsersFeed {
     return new BlockedUsersFeed(this.client);
   }
-  public directInbox(): DirectInboxFeed {
-    return new DirectInboxFeed(this.client);
+  public directInbox(limit: number = 20): DirectInboxFeed {
+    const feed = new DirectInboxFeed(this.client);
+    feed.limit = limit;
+    return feed;
   }
 
   public directPending(): DirectPendingInboxFeed {

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -4,7 +4,8 @@ import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../
 import { DirectThreadEntity } from '../entities';
 
 export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
-  limit: number;
+  @Expose()
+  limit: number = 20;
   @Expose()
   private cursor: string;
   @Expose()
@@ -26,7 +27,7 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
         seq_id: this.seqId,
         thread_message_limit: 10,
         persistentBadging: true,
-        limit: this.limit ? this.limit : 20,
+        limit: this.limit,
       },
     });
     this.state = body;

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -4,6 +4,7 @@ import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../
 import { DirectThreadEntity } from '../entities';
 
 export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
+  limit: number;
   @Expose()
   private cursor: string;
   @Expose()
@@ -25,7 +26,7 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
         seq_id: this.seqId,
         thread_message_limit: 10,
         persistentBadging: true,
-        limit: 20,
+        limit: this.limit ? this.limit : 20,
       },
     });
     this.state = body;


### PR DESCRIPTION
DirectInboxFeed receives the parameter Limit. Its allow the developer to receive more than 20 threads.

```const ig = new IgApiClient();
  const inboxFeed = ig.feed.directInbox();
  inboxFeed.limit = 10;
  let threads = await inboxFeed.items();
```
The default value is 20. 