### PR TITLE
show_many endpoint

### DIFF
--- a/src/repositories/friendship.repository.ts
+++ b/src/repositories/friendship.repository.ts
@@ -9,6 +9,19 @@ export class FriendshipRepository extends Repository {
     return body;
   }
 
+  async showMany(ids: number[]) {
+        const { body } = await this.client.request.send({
+            url: `/api/v1/friendships/show_many/`,
+            method: 'POST',
+            form: {
+                _csrftoken: this.client.state.cookieCsrfToken,
+                user_ids: ids.join(),
+                _uuid: this.client.state.uuid
+            },
+        });
+        return body.friendship_statuses;
+  }
+
   async create(id: string | number, mediaIdAttribution?: string) {
     return this.change('create', id, mediaIdAttribution);
   }

--- a/src/repositories/friendship.repository.ts
+++ b/src/repositories/friendship.repository.ts
@@ -15,7 +15,7 @@ export class FriendshipRepository extends Repository {
             method: 'POST',
             form: {
                 _csrftoken: this.client.state.cookieCsrfToken,
-                user_ids: JSON.stringify(userIds),
+                user_ids: userIds.join(),
                 _uuid: this.client.state.uuid
             },
         });

--- a/src/repositories/friendship.repository.ts
+++ b/src/repositories/friendship.repository.ts
@@ -9,13 +9,13 @@ export class FriendshipRepository extends Repository {
     return body;
   }
 
-  async showMany(ids: number[]) {
+  async showMany(userIds: string[] | number[]) {
         const { body } = await this.client.request.send({
             url: `/api/v1/friendships/show_many/`,
             method: 'POST',
             form: {
                 _csrftoken: this.client.state.cookieCsrfToken,
-                user_ids: ids.join(),
+                user_ids: JSON.stringify(userIds),
                 _uuid: this.client.state.uuid
             },
         });


### PR DESCRIPTION
Added show_many endpoint to friendship repository. This allows users to get the friendship status of multiple users in one single request.