### PR TITLE
Implement tags feed (media with specific tags)

### DIFF
--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -19,6 +19,7 @@ import {
   ReelsTrayFeed,
   SavedFeed,
   TagFeed,
+  TagsFeed,
   TimelineFeed,
   UserFeed,
   UsertagsFeed,
@@ -88,6 +89,13 @@ export class FeedFactory {
   public tag(tag: string): TagFeed {
     const feed = new TagFeed(this.client);
     feed.tag = tag;
+    return feed;
+  }
+
+  public tags(tag: string, tab: 'top' | 'recent' | 'places' = 'top'): TagsFeed {
+    const feed = new TagsFeed(this.client);
+    feed.tag = tag;
+    feed.tab = tab;
     return feed;
   }
 

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -11,6 +11,7 @@ export * from './news.feed';
 export * from './reels-media.feed';
 export * from './saved.feed';
 export * from './tag.feed';
+export * from './tags.feed';
 export * from './timeline.feed';
 export * from './user.feed';
 export * from './direct-pending.feed';

--- a/src/feeds/tags.feed.ts
+++ b/src/feeds/tags.feed.ts
@@ -1,0 +1,51 @@
+import { flatten } from 'lodash';
+import { Expose } from 'class-transformer';
+import { Feed } from '../core/feed';
+import { TagsFeedResponse, TagsFeedResponseMedia } from '../responses';
+
+export class TagsFeed extends Feed<TagsFeedResponse, TagsFeedResponseMedia> {
+  tag: string;
+  tab: 'top' | 'recent' | 'places';
+  @Expose()
+  private nextMaxId: string;
+  @Expose()
+  private nextPage: number;
+  @Expose()
+  private nextMediaIds: Array<string> = [];
+
+  protected set state(body: TagsFeedResponse) {
+    this.moreAvailable = body.more_available;
+    this.nextMaxId = body.next_max_id;
+    this.nextPage = body.next_page;
+    this.nextMediaIds = body.next_media_ids;
+  }
+
+  public async request() {
+    const { body } = await this.client.request.send<TagsFeedResponse>({
+      url: `/api/v1/tags/${encodeURI(this.tag)}/sections/`,
+      method: 'POST',
+      form: {
+        _csrftoken: this.client.state.cookieCsrfToken,
+        tab: this.tab,
+        _uuid: this.client.state.uuid,
+        session_id: this.client.state.clientSessionId,
+        page: this.nextPage,
+        next_media_ids: this.nextPage ? JSON.stringify(this.nextMediaIds) : void 0,
+        max_id: this.nextMaxId,
+      },
+    });
+    this.state = body;
+    return body;
+  }
+
+  public async items() {
+    const response = await this.request();
+    return flatten(
+      response.sections.map(section => {
+        if (section.layout_type !== 'media_grid') return;
+
+        return section.layout_content.medias.map(medias => medias.media);
+      }),
+    );
+  }
+}

--- a/src/repositories/tag.repository.ts
+++ b/src/repositories/tag.repository.ts
@@ -13,4 +13,16 @@ export class TagRepository extends Repository {
     });
     return body;
   }
+
+  public async section(q: string, tab: string) {
+    const { body } = await this.client.request.send<TagRepositorySearchResponseRootObject>({
+      url: `/api/v1/tags/${encodeURI(q)}/sections/`,
+      qs: {
+        timezone_offset: this.client.state.timezoneOffset,
+        tab: tab,
+        count: 30,
+      },
+    });
+    return body;
+  }
 }

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -49,6 +49,7 @@ export * from './media-comments.feed.response';
 export * from './reels-media.feed.response';
 export * from './spam.response';
 export * from './tag.feed.response';
+export * from './tags.feed.response';
 export * from './tag.repository.search.response';
 export * from './timeline.feed.response';
 export * from './upload.repository.photo.response';

--- a/src/responses/tag.repository.section.response.ts
+++ b/src/responses/tag.repository.section.response.ts
@@ -1,0 +1,15 @@
+export interface TagRepositorySectionResponseRootObject {
+  sections: TagRepositorySectionResponsesectionsItem[];
+  more_available: boolean;
+  next_max_id: string;
+  next_page: number;
+  next_media_ids: string[];
+  auto_load_more_enabled: boolean;
+  status: string;
+}
+export interface TagRepositorySectionResponsesectionsItem {
+  layout_type: string;
+  layout_content: string[];
+  feed_type: string;
+  explore_item_info: string[];
+}

--- a/src/responses/tags.feed.response.ts
+++ b/src/responses/tags.feed.response.ts
@@ -1,0 +1,175 @@
+export interface TagsFeedResponse {
+  sections: TagsFeedResponseSectionsItem[];
+  more_available: boolean;
+  next_page: number;
+  next_media_ids: string[];
+  next_max_id: string;
+  status: string;
+}
+export interface TagsFeedResponseSectionsItem {
+  layout_type: string;
+  layout_content: TagsFeedResponseLayout_content;
+  feed_type: string;
+  explore_item_info: TagsFeedResponseExplore_item_info;
+}
+export interface TagsFeedResponseLayout_content {
+  medias: TagsFeedResponseMediasItem[];
+}
+export interface TagsFeedResponseMediasItem {
+  media: TagsFeedResponseMedia;
+}
+export interface TagsFeedResponseMedia {
+  taken_at: number;
+  pk: string;
+  id: string;
+  device_timestamp: string | number;
+  media_type: number;
+  code: string;
+  client_cache_key: string;
+  filter_type: number;
+  comment_likes_enabled: boolean;
+  comment_threading_enabled: boolean;
+  has_more_comments: boolean;
+  next_max_id: string;
+  max_num_visible_preview_comments: number;
+  preview_comments: TagsFeedResponsePreviewCommentsItem[];
+  can_view_more_preview_comments: boolean;
+  comment_count: number;
+  carousel_media_count?: number;
+  carousel_media?: TagsFeedResponseCarouselMediaItem[];
+  can_see_insights_as_brand?: boolean;
+  Tags: TagsFeedResponseTags;
+  lat: string;
+  lng: string;
+  user: TagsFeedResponseUser;
+  can_viewer_reshare: boolean;
+  caption: TagsFeedResponseCaption | null;
+  caption_is_edited: boolean;
+  like_count: number;
+  has_liked: boolean;
+  top_likers: any[];
+  photo_of_you: boolean;
+  can_viewer_save: boolean;
+  organic_tracking_token: string;
+  image_versions2?: TagsFeedResponseImage_versions2;
+  original_width?: number;
+  original_height?: number;
+  usertags?: TagsFeedResponseUsertags;
+  is_dash_eligible?: number;
+  video_dash_manifest?: string;
+  video_codec?: string;
+  number_of_qualities?: number;
+  video_versions?: TagsFeedResponseVideoVersionsItem[];
+  has_audio?: boolean;
+  video_duration?: number;
+  view_count?: number;
+  commenting_disabled_for_viewer?: boolean;
+}
+export interface TagsFeedResponsePreviewCommentsItem {
+  pk: string;
+  user_id: number;
+  text: string;
+  type: number;
+  created_at: number;
+  created_at_utc: number;
+  content_type: string;
+  status: string;
+  bit_flags: number;
+  user: TagsFeedResponseUser;
+  did_report_as_spam: boolean;
+  share_enabled: boolean;
+  media_id: string;
+  has_translation?: boolean;
+  parent_comment_id?: string;
+}
+export interface TagsFeedResponseUser {
+  pk: number;
+  username: string;
+  full_name: string;
+  is_private: boolean;
+  profile_pic_url: string;
+  profile_pic_id?: string;
+  is_verified?: boolean;
+  friendship_status?: TagsFeedResponseFriendship_status;
+  has_anonymous_profile_picture?: boolean;
+  is_unpublished?: boolean;
+  is_favorite?: boolean;
+}
+export interface TagsFeedResponseCarouselMediaItem {
+  id: string;
+  media_type: number;
+  image_versions2: TagsFeedResponseImage_versions2;
+  original_width: number;
+  original_height: number;
+  pk: string;
+  carousel_parent_id: string;
+  usertags?: TagsFeedResponseUsertags;
+  video_versions?: TagsFeedResponseVideoVersionsItem[];
+  video_duration?: number;
+  is_dash_eligible?: number;
+  video_dash_manifest?: string;
+  video_codec?: string;
+  number_of_qualities?: number;
+}
+export interface TagsFeedResponseImage_versions2 {
+  candidates: TagsFeedResponseCandidatesItem[];
+}
+export interface TagsFeedResponseCandidatesItem {
+  width: number;
+  height: number;
+  url: string;
+}
+export interface TagsFeedResponseTags {
+  pk: number;
+  name: string;
+  address: string;
+  city: string;
+  short_name: string;
+  lng: string;
+  lat: string;
+  external_source: string;
+  facebook_places_id: string;
+}
+export interface TagsFeedResponseFriendship_status {
+  following: boolean;
+  outgoing_request: boolean;
+  is_bestie: boolean;
+}
+export interface TagsFeedResponseCaption {
+  pk: string;
+  user_id: number;
+  text: string;
+  type: number;
+  created_at: number;
+  created_at_utc: number;
+  content_type: string;
+  status: string;
+  bit_flags: number;
+  user: TagsFeedResponseUser;
+  did_report_as_spam: boolean;
+  share_enabled: boolean;
+  media_id: string;
+  has_translation?: boolean;
+}
+export interface TagsFeedResponseUsertags {
+  in: TagsFeedResponseInItem[];
+}
+export interface TagsFeedResponseInItem {
+  user: TagsFeedResponseUser;
+  position: number[] | (number | string)[];
+  start_time_in_video_in_sec: null;
+  duration_in_video_in_sec: null;
+}
+export interface TagsFeedResponseExplore_item_info {
+  num_columns: number;
+  total_num_columns: number;
+  aspect_ratio: number;
+  autoplay: boolean;
+}
+export interface TagsFeedResponseVideoVersionsItem {
+  type: number;
+  width: number;
+  height: number;
+  url: string;
+  id: string;
+}


### PR DESCRIPTION
This PR implements tags feed function.
Tags feed is used to get media with specific tags in captions.

* There's already feed function named tag, which lists up tags for autocompletion. "feed.tag" and "feed.tags" might be confusing but I couldn't think of a better name than "feed.tags".
* This function is very similar to location feeds. I reused a lot of code from location feeds so a lot of code could be refactored.
* Unlike location feed, tags feed has a full_width layout type section for the top area. I didn't implement this.

Feedbacks are welcome.