### PR TITLE
Remove EULA text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,3 @@ Plus we need some documentation, so if you are good in it - you are welcome.
 ## Thanks to contributors
 
 - [Nerixyz](https://github.com/Nerixyz), for writing a huge amount of code for this library.
-
-## End User License Agreement (EULA)
-
-1. _You will not use_ this repository for sending mass spam or any other malicious activity
-2. _We / You will not support_ anyone who is violating this EULA conditions
-3. _Repository is just for learning / personal purposes_ thus should not be part of any
-   service available on the Internet that is trying to do any malicious activity (mass bulk request, spam etc.)


### PR DESCRIPTION
This text directly conflicts with the MIT license in the LICENSE file as well as with the `license` field in `package.json`. Presumably those are more important to the authors (and presumably that's the license that all contributors intended to contribute under), hence this PR. If that's not the case then that's of course your prerogative but then you should remove the MIT license from the project.