### PR TITLE
Update Discover Feed

### DIFF
--- a/src/feeds/discover.feed.ts
+++ b/src/feeds/discover.feed.ts
@@ -7,8 +7,8 @@ export class DiscoverFeed extends Feed<DiscoverFeedResponseRootObject, DiscoverF
   private nextMaxId: string;
 
   set state(body: DiscoverFeedResponseRootObject) {
-    this.moreAvailable = !!body.next_max_id;
-    this.nextMaxId = body.next_max_id;
+    this.moreAvailable = body.more_available;
+    this.nextMaxId = body.max_id;
   }
 
   async request() {


### PR DESCRIPTION
Discover feed works a little different than the other feeds. Body returns max_id and not next_max_id. Also to check if there is more, the body returns a property called more_available.