### PR TITLE
Replying to stories and a fix for direct stories

### DIFF
--- a/src/entities/direct-thread.entity.ts
+++ b/src/entities/direct-thread.entity.ts
@@ -128,15 +128,10 @@ export class DirectThreadEntity extends Entity {
   /**
    * Uploads a story to the thread
    * The story is either destroyable (view 'once') or 'replayable'
-   * @param options
+   * @param input
    */
-  public async broadcastStory(options: DirectThreadBroadcastStoryOptions) {
-    if (typeof options.file === 'undefined') {
-      // TODO: remove in future releases
-      throw new IgClientError(
-        'Deprecated: DirectThreadEntity.broadcastStory() no longer accepts a Buffer, use {file: Buffer} instead.',
-      );
-    }
+  public async broadcastStory(input: Buffer | DirectThreadBroadcastStoryOptions) {
+    const options = input instanceof Buffer ? { file: input } : input;
     const baseOptions = {
       file: options.file,
       viewMode: options.viewMode || 'replayable',

--- a/src/entities/direct-thread.entity.ts
+++ b/src/entities/direct-thread.entity.ts
@@ -1,6 +1,11 @@
 import * as urlRegex from 'url-regex';
 import { Entity } from '../core/entity';
-import { DirectThreadBroadcastPhotoOptions, DirectThreadBroadcastVideoOptions } from '../types';
+import {
+  DirectThreadBroadcastPhotoOptions,
+  DirectThreadBroadcastReelOptions,
+  DirectThreadBroadcastStoryOptions,
+  DirectThreadBroadcastVideoOptions,
+} from '../types';
 import { DirectThreadBroadcastOptions } from '../types';
 import { IgClientError } from '../errors';
 import { PublishService } from '../services/publish.service';
@@ -26,6 +31,36 @@ export class DirectThreadEntity extends Entity {
       form: {
         text,
       },
+    });
+  }
+
+  public async broadcastReel(options: DirectThreadBroadcastReelOptions) {
+    return await this.broadcast({
+      item: 'reel_share',
+      form: {
+        media_id: options.mediaId,
+        reel_id: options.reelId || options.mediaId.split('_')[1],
+        text: options.text,
+        entry: 'reel',
+      },
+      qs: {
+        media_type: options.mediaType || 'photo',
+      },
+    });
+  }
+
+  public async broadcastUserStory(options: DirectThreadBroadcastReelOptions) {
+    return await this.broadcast({
+      item: 'story_share',
+      form: {
+        story_media_id: options.mediaId,
+        reel_id: options.reelId || options.mediaId.split('_')[1],
+        text: options.text,
+      },
+      qs: {
+        media_type: options.mediaType || 'photo',
+      },
+      signed: true,
     });
   }
 
@@ -133,6 +168,8 @@ export class DirectThreadEntity extends Entity {
     const baseParams = {
       item: options.item,
       form: options.form,
+      qs: options.qs,
+      signed: options.signed,
     };
     let params;
     if (this.threadId) {

--- a/src/entities/direct-thread.entity.ts
+++ b/src/entities/direct-thread.entity.ts
@@ -34,6 +34,10 @@ export class DirectThreadEntity extends Entity {
     });
   }
 
+  /**
+   * This is used when replying to a story (swiping up) and it's creator
+   * @param options
+   */
   public async broadcastReel(options: DirectThreadBroadcastReelOptions) {
     return await this.broadcast({
       item: 'reel_share',
@@ -49,6 +53,10 @@ export class DirectThreadEntity extends Entity {
     });
   }
 
+  /**
+   * This is used when sharing a story (app: plane/share button) to a thread
+   * @param options
+   */
   public async broadcastUserStory(options: DirectThreadBroadcastReelOptions) {
     return await this.broadcast({
       item: 'story_share',
@@ -117,16 +125,32 @@ export class DirectThreadEntity extends Entity {
     });
   }
 
-  public async broadcastStory(file: Buffer) {
-    if (this.threadId === null) {
+  /**
+   * Uploads a story to the thread
+   * The story is either destroyable (view 'once') or 'replayable'
+   * @param options
+   */
+  public async broadcastStory(options: DirectThreadBroadcastStoryOptions) {
+    if (typeof options.file === 'undefined') {
+      // TODO: remove in future releases
+      throw new IgClientError(
+        'Deprecated: DirectThreadEntity.broadcastStory() no longer accepts a Buffer, use {file: Buffer} instead.',
+      );
+    }
+    const baseOptions = {
+      file: options.file,
+      viewMode: options.viewMode || 'replayable',
+      replyType: options.replyType,
+    };
+    if (this.threadId !== null) {
       return await this.client.publish.story({
-        file,
+        ...baseOptions,
         threadIds: [this.threadId],
       });
     }
-    if (this.userIds === null) {
+    if (this.userIds !== null) {
       return await this.client.publish.story({
-        file,
+        ...baseOptions,
         recipientUsers: this.userIds,
       });
     }

--- a/src/repositories/direct-thread.repository.ts
+++ b/src/repositories/direct-thread.repository.ts
@@ -209,19 +209,22 @@ export class DirectThreadRepository extends Repository {
     const recipientsType = options.threadIds ? 'thread_ids' : 'recipient_users';
     const recipientsIds = recipients instanceof Array ? recipients : [recipients];
 
+    const form = {
+      action: 'send_item',
+      [recipientsType]: JSON.stringify(recipientsType === 'thread_ids' ? recipientsIds : [recipientsIds]),
+      client_context: mutationToken,
+      _csrftoken: this.client.state.cookieCsrfToken,
+      device_id: this.client.state.deviceId,
+      mutation_token: mutationToken,
+      _uuid: this.client.state.uuid,
+      ...options.form,
+    };
+
     const { body } = await this.client.request.send<DirectThreadRepositoryBroadcastResponseRootObject>({
       url: `/api/v1/direct_v2/threads/broadcast/${options.item}/`,
       method: 'POST',
-      form: {
-        action: 'send_item',
-        [recipientsType]: JSON.stringify(recipientsType === 'thread_ids' ? recipientsIds : [recipientsIds]),
-        client_context: mutationToken,
-        _csrftoken: this.client.state.cookieCsrfToken,
-        device_id: this.client.state.deviceId,
-        mutation_token: mutationToken,
-        _uuid: this.client.state.uuid,
-        ...options.form,
-      },
+      form: options.signed ? this.client.request.sign(form) : form,
+      qs: options.qs,
     });
     return body;
   }

--- a/src/repositories/discover.repository.ts
+++ b/src/repositories/discover.repository.ts
@@ -2,13 +2,12 @@ import { Repository } from '../core/repository';
 import { DiscoverRepositoryChainingResponseRootObject } from '../responses/discover.repository.chaining.response';
 
 export class DiscoverRepository extends Repository {
-
   /**
    * Gets the suggestions based on a user
    * @param targetId user id/pk
    */
   async chaining(targetId: string): Promise<DiscoverRepositoryChainingResponseRootObject> {
-    const {body} = await this.client.request.send<DiscoverRepositoryChainingResponseRootObject>({
+    const { body } = await this.client.request.send<DiscoverRepositoryChainingResponseRootObject>({
       url: '/api/v1/discover/chaining/',
       qs: {
         target_id: targetId,

--- a/src/repositories/media.repository.ts
+++ b/src/repositories/media.repository.ts
@@ -394,7 +394,6 @@ export class MediaRepository extends Repository {
       width,
       height,
 
-      upload_id: Date.now().toString(),
       source_type: '3',
       configure_mode: '1',
       client_shared_at: now.toString(),
@@ -409,6 +408,11 @@ export class MediaRepository extends Repository {
 
     if (form.configure_mode === '1') {
       MediaRepository.stringifyStoryStickers(form);
+    } else if (form.configure_mode === '2') {
+      if (typeof form.recipient_users !== 'string') {
+        form.recipient_users = JSON.stringify(form.recipient_users ? [form.recipient_users.map(x => Number(x))] : []);
+      }
+      form.thread_ids = JSON.stringify(form.thread_ids || []);
     }
 
     const { body } = await this.client.request.send({

--- a/src/responses/discover.repository.chaining.response.ts
+++ b/src/responses/discover.repository.chaining.response.ts
@@ -1,22 +1,22 @@
 export interface DiscoverRepositoryChainingResponseRootObject {
-    users: DiscoverRepositoryChainingResponseUsersItem[];
-    is_backup: boolean;
-    is_recommend_account: boolean;
-    available_recommend_count: number;
-    status: string;
+  users: DiscoverRepositoryChainingResponseUsersItem[];
+  is_backup: boolean;
+  is_recommend_account: boolean;
+  available_recommend_count: number;
+  status: string;
 }
 export interface DiscoverRepositoryChainingResponseUsersItem {
-    pk: number;
-    username: string;
-    full_name: string;
-    is_private: boolean;
-    profile_pic_url: string;
-    profile_pic_id?: string;
-    is_verified: boolean;
-    chaining_info: DiscoverRepositoryChainingResponseChaining_info;
-    profile_chaining_secondary_label: string;
-    social_context: string;
+  pk: number;
+  username: string;
+  full_name: string;
+  is_private: boolean;
+  profile_pic_url: string;
+  profile_pic_id?: string;
+  is_verified: boolean;
+  chaining_info: DiscoverRepositoryChainingResponseChaining_info;
+  profile_chaining_secondary_label: string;
+  social_context: string;
 }
 export interface DiscoverRepositoryChainingResponseChaining_info {
-    sources: string;
+  sources: string;
 }

--- a/src/services/publish.service.ts
+++ b/src/services/publish.service.ts
@@ -18,6 +18,7 @@ import { PostingLocation, PostingStoryOptions } from '../types/posting.options';
 import Bluebird = require('bluebird');
 import { IgConfigureVideoError, IgResponseError, IgUploadVideoError } from '../errors';
 import { UploadRepositoryVideoResponseRootObject } from '../responses';
+import Chance = require('chance');
 
 export class PublishService extends Repository {
   /**
@@ -277,12 +278,13 @@ export class PublishService extends Repository {
     const recipients = typeof options.recipientUsers !== 'undefined';
     if (recipients || threadIds) {
       configureOptions.configure_mode = '2';
+      configureOptions.view_mode = options.viewMode;
+      configureOptions.reply_type = options.replyType;
+      configureOptions.client_context = new Chance().guid();
       if (recipients) {
         configureOptions.recipient_users = options.recipientUsers;
       }
-      if (threadIds) {
-        configureOptions.thread_ids = options.threadIds;
-      }
+      configureOptions.thread_ids = threadIds ? options.threadIds : [];
       return uploadAndConfigure();
     }
 

--- a/src/types/direct-thread.broadcast-media.options.ts
+++ b/src/types/direct-thread.broadcast-media.options.ts
@@ -9,3 +9,9 @@ export interface DirectThreadBroadcastVideoOptions {
   uploadId?: string;
   sampled?: boolean;
 }
+
+export interface DirectThreadBroadcastStoryOptions {
+  file: Buffer;
+  viewMode?: 'replayable' | 'once' | string;
+  replyType?: 'story' | string;
+}

--- a/src/types/direct-thread.broadcast-reel.options.ts
+++ b/src/types/direct-thread.broadcast-reel.options.ts
@@ -1,0 +1,6 @@
+export interface DirectThreadBroadcastReelOptions {
+  mediaId: string;
+  reelId?: string;
+  text?: string;
+  mediaType?: 'photo' | 'video';
+}

--- a/src/types/direct-thread.broadcast.options.ts
+++ b/src/types/direct-thread.broadcast.options.ts
@@ -11,6 +11,8 @@ interface CreateThreadOptions {
 interface DirectTreadBroadcastBaseOptions {
   item: string;
   form?: { [x: string]: any };
+  qs?: { [x: string]: any };
+  signed?: boolean;
 }
 
 export type DirectThreadBroadcastOptions = DirectTreadBroadcastBaseOptions &

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,3 +20,4 @@ export * from './create-highlights-reel.options';
 export * from './edit-highlights-reel.options';
 export * from './graphql-request.options';
 export * from './insights.options';
+export * from './direct-thread.broadcast-reel.options';

--- a/src/types/media.configure-story.options.ts
+++ b/src/types/media.configure-story.options.ts
@@ -8,8 +8,14 @@ export interface MediaConfigureStoryBaseOptions {
   // 1 = story-reel, 2 = direct-story (does not support stickers)
   configure_mode: '1' | '2';
   camera_position?: string;
-  thread_ids?: string[];
-  recipient_users?: string[];
+  allow_multi_configures?: '0' | '1';
+
+  // direct-story share options
+  thread_ids?: string[] | string;
+  recipient_users?: string[] | string;
+  client_context?: string;
+  view_mode?: 'replayable' | 'once' | string;
+  reply_type?: 'story' | string;
 
   caption?: string;
   mas_opt_in?: 'NOT_PROMPTED';

--- a/src/types/posting.options.ts
+++ b/src/types/posting.options.ts
@@ -29,6 +29,8 @@ export interface PostingStoryOptions {
   toBesties?: boolean;
   threadIds?: string[];
   recipientUsers?: string[];
+  viewMode?: 'replayable' | 'once' | string;
+  replyType?: 'story' | string;
 
   // stickers
   location?: PostingStoryLocationSticker;


### PR DESCRIPTION
This adds the possibility to reply to stories (#922 ) and the sharing of them.
**Breaking:**
`DirectThreadEntity.broadcastStory()` now requires an object instead of a Buffer.

Direct stories can now be set to "self-destroy" by setting `viewMode` to 'once'.
Examples:
```ts
function replyToStory(story: { id: string, user: { pk: number | string }, media_type: number }, text: string) {
  return ig.entity.directThread([story.user.pk.toString()]).broadcastReel({
    mediaId: story.id,
    mediaType: story.media_type === 1 ? 'photo' : 'video',
    text,
  });
}

function shareStory(story: { id: string, media_type: number }, target: string | string[], text?: string) {
  return ig.entity.directThread(target).broadcastUserStory({
    mediaId: story.id,
    mediaType: story.media_type === 1 ? 'photo' : 'video',
    text,
  });
}
```