### PR TITLE
Allow CookieJar.Serialized cookies as input to deserializeCookieJar

### DIFF
--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -164,7 +164,7 @@ export class State {
     }
   }
 
-  public async deserializeCookieJar(cookies: string) {
+  public async deserializeCookieJar(cookies: string | CookieJar.Serialized) {
     this.cookieJar['_jar'] = await Bluebird.fromCallback(cb => CookieJar.deserialize(cookies, this.cookieStore, cb));
   }
 


### PR DESCRIPTION
deserializeCookieJar calls `CookieJar.deserialize`, a function that actually accepts either the string or object CookieJar.

See https://github.com/salesforce/tough-cookie/blob/master/lib/cookie.js#L1457
or https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/tough-cookie/index.d.ts#L150

This allows `deserializeCookieJar` to have the same signature, allowing both a string and an object.