### PR TITLE
Get Encryption Key If It's Not Present

### DIFF
--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -23,6 +23,9 @@ import * as crypto from 'crypto';
 export class AccountRepository extends Repository {
   private static accountDebug = debug('ig:account');
   public async login(username: string, password: string): Promise<AccountRepositoryLoginResponseLogged_in_user> {
+    if (!this.client.state.passwordEncryptionPubKey) {
+      await this.client.qe.syncLoginExperiments();
+    }
     const {encrypted, time} = this.encryptPassword(password);
     const response = await Bluebird.try(() =>
       this.client.request.send<AccountRepositoryLoginResponseRootObject>({


### PR DESCRIPTION
Seeing #1055 and #1056 , in a short amount of time, this should be added as a 'fix'. 
*Maybe the user could be notified to use ig.simulate.preLoginFlow?*