### PR TITLE
grab-user-data

### DIFF
--- a/examples/session.example.ts
+++ b/examples/session.example.ts
@@ -19,6 +19,7 @@ function fakeLoad() {
 
 (async () => {
   const ig = new IgApiClient();
+  let userInfo;
   ig.state.generateDevice(process.env.IG_USERNAME);
   ig.state.proxyUrl = process.env.IG_PROXY;
   // This function executes after every request
@@ -31,8 +32,12 @@ function fakeLoad() {
     // import state accepts both a string as well as an object
     // the string should be a JSON object
     await ig.state.deserialize(fakeLoad());
+    //Get user data based on loaded cookie
+    userInfo = await ig.user.info(ig.state.cookieUserId);
   }
-  // This call will provoke request.end$ stream
-  await ig.account.login(process.env.IG_USERNAME, process.env.IG_PASSWORD);
-  // Most of the time you don't have to login after loading the state
+  if(!userInfo){
+    // This call will provoke request.end$ stream
+    userInfo = await ig.account.login(process.env.IG_USERNAME, process.env.IG_PASSWORD);
+    // Most of the time you don't have to login after loading the state
+  }
 })();


### PR DESCRIPTION
I am new to instagram-private-api. I had to go through issues to know how to retrieve user-data after loading the cookie in ig.state after **deserialize()** which we get when we login for the first time.

I think this should be there in the example. Thanks :dagger: 

Response data something like : 
```
{
    pk: number;
    username: string;
    full_name: string;
    is_private: boolean;
    profile_pic_url: string;
    profile_pic_id: string;
    is_verified: boolean;
    has_anonymous_profile_picture: boolean;
    can_boost_post: boolean;
    is_business: boolean;
    account_type: number;
    is_call_to_action_enabled: null;
    can_see_organic_insights: boolean;
    show_insights_terms: boolean;
    reel_auto_archive: string;
    has_placed_orders: boolean;
    allowed_commenter_type: string;
    nametag: AccountRepositoryLoginResponseNametag;
    allow_contacts_sync: boolean;
    phone_number: string;
    country_code: number;
    national_number: number;
}
```

Linked Issue: #1006