### PR TITLE
Fix: error if user story feed is empty

### DIFF
--- a/src/feeds/user-story.feed.ts
+++ b/src/feeds/user-story.feed.ts
@@ -6,6 +6,9 @@ export class UserStoryFeed extends Feed<UserStoryFeedResponseRootObject, UserSto
 
   async items(): Promise<UserStoryFeedResponseItemsItem[]> {
     const response = await this.request();
+    if (!response.reel) {
+      return [];
+    }
     return response.reel.items;
   }
 


### PR DESCRIPTION
Return an empty array if the user story feed is empty.