### PR TITLE
new func: ig.live.addPostLiveToIgtv()

### DIFF
--- a/src/repositories/live.repository.ts
+++ b/src/repositories/live.repository.ts
@@ -12,6 +12,7 @@ import {
   LiveGetQuestionsResponseRootObject,
   LiveLikeResponseRootObject,
   LiveLikeCountResponseRootObject,
+  LivePostLiveThumbnailsResponseRootObject,
   LiveJoinRequestCountsResponseRootObject,
   LiveAddToPostResponse,
 } from '../responses';
@@ -210,6 +211,17 @@ export class LiveRepository extends Repository {
       method: 'GET',
       qs: {
         like_ts: likeTs,
+      },
+    });
+    return body;
+  }
+
+  public async getPostLiveThumbnails(broadcastId: string): Promise<LivePostLiveThumbnailsResponseRootObject> {
+    const { body } = await this.client.request.send<LivePostLiveThumbnailsResponseRootObject>({
+      url: `/api/v1/live/${broadcastId}/get_post_live_thumbnails/`,
+      method: 'GET',
+      qs: {
+        signed_body: this.client.request.sign({}),
       },
     });
     return body;

--- a/src/repositories/live.repository.ts
+++ b/src/repositories/live.repository.ts
@@ -4,6 +4,7 @@ import {
   LiveSwitchCommentsResponseRootObject,
   LiveCreateBroadcastResponseRootObject,
   LiveStartBroadcastResponseRootObject,
+  LiveAddPostLiveToIgtvResponseRootObject,
   LiveCommentsResponseRootObject,
   LiveHeartbeatViewerCountResponseRootObject,
   LiveInfoResponseRootObject,
@@ -275,6 +276,36 @@ export class LiveRepository extends Repository {
         _csrftoken: this.client.state.cookieCsrfToken,
         _uuid: this.client.state.uuid,
         should_send_notifications: sendNotifications,
+      }),
+    });
+    return body;
+  }
+
+  public async addPostLiveToIgtv({
+    broadcastId,
+    title,
+    description,
+    coverUploadId,
+    igtvSharePreviewToFeed = false,
+  }: {
+    broadcastId: string;
+    title: string;
+    description: string;
+    coverUploadId: string;
+    igtvSharePreviewToFeed?: boolean;
+  }): Promise<LiveAddPostLiveToIgtvResponseRootObject> {
+    const { body } = await this.client.request.send<LiveAddPostLiveToIgtvResponseRootObject>({
+      url: `/api/v1/live/add_post_live_to_igtv/`,
+      method: 'POST',
+      form: this.client.request.sign({
+        _csrftoken: this.client.state.cookieCsrfToken,
+        _uuid: this.client.state.uuid,
+        broadcast_id: broadcastId,
+        cover_upload_id: coverUploadId,
+        description: description,
+        title: title,
+        internal_only: false,
+        igtv_share_preview_to_feed: igtvSharePreviewToFeed,
       }),
     });
     return body;

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -35,6 +35,7 @@ export * from './live.like-count.response';
 export * from './live.post-live-thumbnails.response';
 export * from './live.like.response';
 export * from './live.start-broadcast.response';
+export * from './live.add-post-live-to-igtv.response';
 export * from './live.switch-comments.response';
 export * from './live.viewer-list.response';
 export * from './live.add-to-post.response';

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -32,6 +32,7 @@ export * from './live.heartbeat-viewer-count.response';
 export * from './live.info.response';
 export * from './live.join-request-counts.response';
 export * from './live.like-count.response';
+export * from './live.post-live-thumbnails.response';
 export * from './live.like.response';
 export * from './live.start-broadcast.response';
 export * from './live.switch-comments.response';

--- a/src/responses/live.add-post-live-to-igtv.response.ts
+++ b/src/responses/live.add-post-live-to-igtv.response.ts
@@ -1,0 +1,5 @@
+export interface LiveAddPostLiveToIgtvResponseRootObject {
+  success: boolean;
+  igtv_post_id: number;
+  status: string;
+}

--- a/src/responses/live.post-live-thumbnails.response.ts
+++ b/src/responses/live.post-live-thumbnails.response.ts
@@ -1,4 +1,4 @@
 export interface LivePostLiveThumbnailsResponseRootObject {
-  thumbnails: any[];
+  thumbnails: string[];
   status: string;
 }

--- a/src/responses/live.post-live-thumbnails.response.ts
+++ b/src/responses/live.post-live-thumbnails.response.ts
@@ -1,0 +1,4 @@
+export interface LivePostLiveThumbnailsResponseRootObject {
+  thumbnails: any[];
+  status: string;
+}


### PR DESCRIPTION
#1190 feature request 

This function saves the live to IGTV.
I will give an example usage.

```

//Save to IGTV

//Get live thumbnails, required to post on IGTV
r=await ig.live.getPostLiveThumbnails(bc.broadcast_id)

//Download any one
func = callback=>https.get(r.thumbnails[0],res=>{
  ds=[];
  res.on("data",d=>ds.push(d));
  res.on("end",()=>{callback(Buffer.concat(ds))}) 
})
file = await new Promise(func)

//It will be a png, it must be converted to jpg (I will use a library)
pngToJpeg = require('png-to-jpeg'); 
file = await pngToJpeg({quality: 90})(file) 

//Upload the thumbnail and get uploadId
r=await ig.upload.photo({file})

//Post live to IGTV
await ig.live.addPostLiveToIgtv({broadcastId:bc.broadcast_id,title:"Some title",description:"Some description",coverUploadId:r.upload_id})

```