### PR TITLE
feat: add options object to specify custom params for feed.items()

### DIFF
--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -84,22 +84,29 @@ export class FeedFactory {
     return new BlockedUsersFeed(this.client);
   }
 
-  public directInbox(): DirectInboxFeed {
-    return new DirectInboxFeed(this.client);
+  public directInbox(options: { limit: number; thread_message_limit: number }): DirectInboxFeed {
+    const feed = new DirectInboxFeed(this.client);
+    feed.limit = options.limit;
+    feed.thread_message_limit = options?.thread_message_limit;
+    return feed;
   }
 
-  public directPending(): DirectPendingInboxFeed {
-    return new DirectPendingInboxFeed(this.client);
+  public directPending(options: { limit: number; thread_message_limit: number }): DirectPendingInboxFeed {
+    const feed = new DirectPendingInboxFeed(this.client);
+    feed.limit = options.limit;
+    feed.thread_message_limit = options?.thread_message_limit;
+    return feed;
   }
 
   public directThread(
-    options: Pick<DirectInboxFeedResponseThreadsItem, 'thread_id' | 'oldest_cursor'>,
+    options: Pick<DirectInboxFeedResponseThreadsItem, 'thread_id' | 'oldest_cursor'> & { limit: number },
     seqId?: number,
   ): DirectThreadFeed {
     const feed = new DirectThreadFeed(this.client);
     feed.id = options.thread_id;
     feed.cursor = options.oldest_cursor;
     feed.seqId = seqId;
+    feed.limit = options?.limit;
     return feed;
   }
 

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -84,16 +84,16 @@ export class FeedFactory {
     return new BlockedUsersFeed(this.client);
   }
 
-  public directInbox(options: { limit: number; thread_message_limit: number }): DirectInboxFeed {
+  public directInbox(options?: { limit: number; thread_message_limit: number }): DirectInboxFeed {
     const feed = new DirectInboxFeed(this.client);
-    feed.limit = options.limit;
+    feed.limit = options?.limit;
     feed.thread_message_limit = options?.thread_message_limit;
     return feed;
   }
 
-  public directPending(options: { limit: number; thread_message_limit: number }): DirectPendingInboxFeed {
+  public directPending(options?: { limit: number; thread_message_limit: number }): DirectPendingInboxFeed {
     const feed = new DirectPendingInboxFeed(this.client);
-    feed.limit = options.limit;
+    feed.limit = options?.limit;
     feed.thread_message_limit = options?.thread_message_limit;
     return feed;
   }

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -84,18 +84,12 @@ export class FeedFactory {
     return new BlockedUsersFeed(this.client);
   }
 
-  public directInbox(options?: { limit: number; thread_message_limit: number }): DirectInboxFeed {
-    const feed = new DirectInboxFeed(this.client);
-    feed.limit = options?.limit;
-    feed.thread_message_limit = options?.thread_message_limit;
-    return feed;
+  public directInbox(options: { limit?: number; thread_message_limit?: number } = {}): DirectInboxFeed {
+    return plainToClassFromExist(new DirectInboxFeed(this.client), options);
   }
 
-  public directPending(options?: { limit: number; thread_message_limit: number }): DirectPendingInboxFeed {
-    const feed = new DirectPendingInboxFeed(this.client);
-    feed.limit = options?.limit;
-    feed.thread_message_limit = options?.thread_message_limit;
-    return feed;
+  public directPending(options: { limit?: number; thread_message_limit?: number } = {}): DirectPendingInboxFeed {
+    return plainToClassFromExist(new DirectPendingInboxFeed(this.client), options);
   }
 
   public directThread(
@@ -106,7 +100,7 @@ export class FeedFactory {
     feed.id = options.thread_id;
     feed.cursor = options.oldest_cursor;
     feed.seqId = seqId;
-    feed.limit = options?.limit;
+    feed.limit = options.limit;
     return feed;
   }
 

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -29,7 +29,7 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
         seq_id: this.seqId,
         thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
         persistentBadging: true,
-        limit: this.limit ?? this.limit,
+        limit: this.limit ?? this.defaultLimit,
       },
     });
     this.state = body;

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -3,12 +3,6 @@ import { Feed } from '../core/feed';
 import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
 import { DirectThreadEntity } from '../entities';
 
-interface DirectInboxFeedItemsOptions {
-  cursor?: string;
-  thread_message_limit?: number;
-  limit?: number;
-}
-
 export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
   @Expose()
   private cursor: string;
@@ -25,25 +19,25 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
     this.cursor = body.inbox.oldest_cursor;
   }
 
-  async request(opts?: DirectInboxFeedItemsOptions) {
+  async request() {
     const { body } = await this.client.request.send<DirectInboxFeedResponse>({
       url: `/api/v1/direct_v2/inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: opts.cursor ?? this.cursor,
+        cursor: this.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
         thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
         persistentBadging: true,
-        limit: opts.limit ?? this.limit,
+        limit: this.limit ?? this.limit,
       },
     });
     this.state = body;
     return body;
   }
 
-  async items(opts?: DirectInboxFeedItemsOptions) {
-    const response = await this.request(opts);
+  async items() {
+    const response = await this.request();
     return response.inbox.threads;
   }
 

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -15,6 +15,10 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
   @Expose()
   private seqId: number;
 
+  public limit: number;
+  public defaultLimit = 20;
+  public thread_message_limit: number;
+  public defaultThreadMessageLimit: number;
   set state(body: DirectInboxFeedResponse) {
     this.moreAvailable = body.inbox.has_older;
     this.seqId = body.seq_id;
@@ -29,9 +33,9 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
         cursor: opts.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: opts.thread_message_limit ?? 10,
+        thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
         persistentBadging: true,
-        limit: opts.limit ?? 20,
+        limit: opts.limit ?? this.limit,
       },
     });
     this.state = body;

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -9,10 +9,8 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
   @Expose()
   private seqId: number;
 
-  public limit: number;
-  public defaultLimit = 20;
-  public thread_message_limit: number;
-  public defaultThreadMessageLimit: number;
+  public limit?: number;
+  public thread_message_limit?: number;
   set state(body: DirectInboxFeedResponse) {
     this.moreAvailable = body.inbox.has_older;
     this.seqId = body.seq_id;
@@ -27,9 +25,9 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
         cursor: this.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
+        thread_message_limit: this.thread_message_limit ?? 10,
         persistentBadging: true,
-        limit: this.limit ?? this.defaultLimit,
+        limit: this.limit ?? 20,
       },
     });
     this.state = body;

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -22,7 +22,7 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
       url: `/api/v1/direct_v2/inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor ?? this.cursor,
+        cursor: this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
         thread_message_limit: this.thread_message_limit ?? 10,

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -3,6 +3,12 @@ import { Feed } from '../core/feed';
 import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
 import { DirectThreadEntity } from '../entities';
 
+interface DirectInboxFeedItemsOptions {
+  cursor?: string;
+  thread_message_limit?: number;
+  limit?: number;
+}
+
 export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
   @Expose()
   private cursor: string;
@@ -15,25 +21,25 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
     this.cursor = body.inbox.oldest_cursor;
   }
 
-  async request() {
+  async request(opts?: DirectInboxFeedItemsOptions) {
     const { body } = await this.client.request.send<DirectInboxFeedResponse>({
       url: `/api/v1/direct_v2/inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor,
+        cursor: opts.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: 10,
+        thread_message_limit: opts.thread_message_limit ?? 10,
         persistentBadging: true,
-        limit: 20,
+        limit: opts.limit ?? 20,
       },
     });
     this.state = body;
     return body;
   }
 
-  async items() {
-    const response = await this.request();
+  async items(opts?: DirectInboxFeedItemsOptions) {
+    const response = await this.request(opts);
     return response.inbox.threads;
   }
 

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -3,12 +3,6 @@ import { Feed } from '../core/feed';
 import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
 import { DirectThreadEntity } from '../entities';
 
-interface DirectPendingInboxFeedItemsOptions {
-  cursor?: string;
-  thread_message_limit?: number;
-  limit?: number;
-}
-
 export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
   @Expose()
   private cursor: string;
@@ -25,7 +19,7 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
     this.cursor = body.inbox.oldest_cursor;
   }
 
-  async request(opts?: DirectPendingInboxFeedItemsOptions) {
+  async request() {
     const { body } = await this.client.request.send<DirectInboxFeedResponse>({
       url: `/api/v1/direct_v2/pending_inbox/`,
       qs: {
@@ -42,8 +36,8 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
     return body;
   }
 
-  async items(opts?: DirectPendingInboxFeedItemsOptions) {
-    const response = await this.request(opts);
+  async items() {
+    const response = await this.request();
     return response.inbox.threads;
   }
 

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -9,10 +9,8 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
   @Expose()
   private seqId: number;
 
-  public limit: number;
-  public defaultLimit = 20;
-  public thread_message_limit: number;
-  public defaultThreadMessageLimit: number;
+  public limit?: number;
+  public thread_message_limit?: number;
   set state(body: DirectInboxFeedResponse) {
     this.moreAvailable = body.inbox.has_older;
     this.seqId = body.seq_id;
@@ -27,9 +25,9 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
         cursor: this.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
+        thread_message_limit: this.thread_message_limit ?? 10,
         persistentBadging: true,
-        limit: this.limit ?? this.defaultLimit,
+        limit: this.limit ?? 20,
       },
     });
     this.state = body;

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -15,6 +15,10 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
   @Expose()
   private seqId: number;
 
+  public limit: number;
+  public defaultLimit = 20;
+  public thread_message_limit: number;
+  public defaultThreadMessageLimit: number;
   set state(body: DirectInboxFeedResponse) {
     this.moreAvailable = body.inbox.has_older;
     this.seqId = body.seq_id;
@@ -26,12 +30,12 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
       url: `/api/v1/direct_v2/pending_inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: opts.cursor ?? this.cursor,
+        cursor: this.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: opts.thread_message_limit ?? 10,
+        thread_message_limit: this.thread_message_limit ?? this.defaultThreadMessageLimit,
         persistentBadging: true,
-        limit: opts.limit ?? 20,
+        limit: this.limit ?? this.defaultLimit,
       },
     });
     this.state = body;

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -3,6 +3,12 @@ import { Feed } from '../core/feed';
 import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
 import { DirectThreadEntity } from '../entities';
 
+interface DirectPendingInboxFeedItemsOptions {
+  cursor?: string;
+  thread_message_limit?: number;
+  limit?: number;
+}
+
 export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
   @Expose()
   private cursor: string;
@@ -15,25 +21,25 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
     this.cursor = body.inbox.oldest_cursor;
   }
 
-  async request() {
+  async request(opts?: DirectPendingInboxFeedItemsOptions) {
     const { body } = await this.client.request.send<DirectInboxFeedResponse>({
       url: `/api/v1/direct_v2/pending_inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor,
+        cursor: opts.cursor ?? this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
-        thread_message_limit: 10,
+        thread_message_limit: opts.thread_message_limit ?? 10,
         persistentBadging: true,
-        limit: 20,
+        limit: opts.limit ?? 20,
       },
     });
     this.state = body;
     return body;
   }
 
-  async items() {
-    const response = await this.request();
+  async items(opts?: DirectPendingInboxFeedItemsOptions) {
+    const response = await this.request(opts);
     return response.inbox.threads;
   }
 

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -22,7 +22,7 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
       url: `/api/v1/direct_v2/pending_inbox/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor ?? this.cursor,
+        cursor: this.cursor,
         direction: this.cursor ? 'older' : void 0,
         seq_id: this.seqId,
         thread_message_limit: this.thread_message_limit ?? 10,

--- a/src/feeds/direct-thread.feed.ts
+++ b/src/feeds/direct-thread.feed.ts
@@ -2,6 +2,11 @@ import { Expose } from 'class-transformer';
 import { Feed } from '../core/feed';
 import { DirectThreadFeedResponse, DirectThreadFeedResponseItemsItem } from '../responses';
 
+interface DirectThreadFeedItemsOptions {
+  cursor?: string;
+  limit?: number;
+}
+
 export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThreadFeedResponseItemsItem> {
   public id: string;
   public seqId: number;
@@ -11,23 +16,23 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
     this.cursor = body.thread.oldest_cursor;
     this.moreAvailable = body.thread.has_older;
   }
-  async request() {
+  async request(opts?: DirectThreadFeedItemsOptions) {
     const { body } = await this.client.request.send<DirectThreadFeedResponse>({
       url: `/api/v1/direct_v2/threads/${this.id}/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor,
+        cursor: opts.cursor ?? this.cursor,
         direction: 'older',
         seq_id: this.seqId,
-        limit: 10,
+        limit: opts.limit ?? 10,
       },
     });
     this.state = body;
     return body;
   }
 
-  async items() {
-    const response = await this.request();
+  async items(opts?: DirectThreadFeedItemsOptions) {
+    const response = await this.request(opts);
     return response.thread.items;
   }
 }

--- a/src/feeds/direct-thread.feed.ts
+++ b/src/feeds/direct-thread.feed.ts
@@ -2,11 +2,6 @@ import { Expose } from 'class-transformer';
 import { Feed } from '../core/feed';
 import { DirectThreadFeedResponse, DirectThreadFeedResponseItemsItem } from '../responses';
 
-interface DirectThreadFeedItemsOptions {
-  cursor?: string;
-  limit?: number;
-}
-
 export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThreadFeedResponseItemsItem> {
   public id: string;
   public seqId: number;
@@ -18,7 +13,7 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
     this.cursor = body.thread.oldest_cursor;
     this.moreAvailable = body.thread.has_older;
   }
-  async request(opts?: DirectThreadFeedItemsOptions) {
+  async request() {
     const { body } = await this.client.request.send<DirectThreadFeedResponse>({
       url: `/api/v1/direct_v2/threads/${this.id}/`,
       qs: {
@@ -33,8 +28,8 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
     return body;
   }
 
-  async items(opts?: DirectThreadFeedItemsOptions) {
-    const response = await this.request(opts);
+  async items() {
+    const response = await this.request();
     return response.thread.items;
   }
 }

--- a/src/feeds/direct-thread.feed.ts
+++ b/src/feeds/direct-thread.feed.ts
@@ -8,7 +8,6 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
   @Expose()
   public cursor: string;
   public limit?: number;
-  public defaultLimit = 10;
   set state(body: DirectThreadFeedResponse) {
     this.cursor = body.thread.oldest_cursor;
     this.moreAvailable = body.thread.has_older;
@@ -21,7 +20,7 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
         cursor: this.cursor ?? this.cursor,
         direction: 'older',
         seq_id: this.seqId,
-        limit: this.limit ?? this.defaultLimit,
+        limit: this.limit ?? 10,
       },
     });
     this.state = body;

--- a/src/feeds/direct-thread.feed.ts
+++ b/src/feeds/direct-thread.feed.ts
@@ -12,6 +12,8 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
   public seqId: number;
   @Expose()
   public cursor: string;
+  public limit?: number;
+  public defaultLimit = 10;
   set state(body: DirectThreadFeedResponse) {
     this.cursor = body.thread.oldest_cursor;
     this.moreAvailable = body.thread.has_older;
@@ -21,10 +23,10 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
       url: `/api/v1/direct_v2/threads/${this.id}/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: opts.cursor ?? this.cursor,
+        cursor: this.cursor ?? this.cursor,
         direction: 'older',
         seq_id: this.seqId,
-        limit: opts.limit ?? 10,
+        limit: this.limit ?? this.defaultLimit,
       },
     });
     this.state = body;

--- a/src/feeds/direct-thread.feed.ts
+++ b/src/feeds/direct-thread.feed.ts
@@ -17,7 +17,7 @@ export class DirectThreadFeed extends Feed<DirectThreadFeedResponse, DirectThrea
       url: `/api/v1/direct_v2/threads/${this.id}/`,
       qs: {
         visual_message_return_type: 'unseen',
-        cursor: this.cursor ?? this.cursor,
+        cursor: this.cursor,
         direction: 'older',
         seq_id: this.seqId,
         limit: this.limit ?? 10,


### PR DESCRIPTION
It is now possible to retrieve as many messages as desired per thread when fetching direct inbox items or direct thread items