### PR TITLE
Add options to followers/following feed

### DIFF
--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -53,24 +53,28 @@ export class FeedFactory {
   constructor(private client: IgApiClient) {}
 
   public accountFollowers(
-    id?: string | number,
-    options?: Partial<Pick<AccountFollowersFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups'>>,
+    options?:
+      | string
+      | number
+      | Partial<Pick<AccountFollowersFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups' | 'id'>>,
   ): AccountFollowersFeed {
     return plainToClassFromExist(new AccountFollowersFeed(this.client), {
-      ...options,
-      id: id || this.client.state.cookieUserId,
+      id: options && typeof options !== 'object' ? options : this.client.state.cookieUserId,
+      ...(typeof options === 'object' ? options : undefined),
     });
   }
 
   public accountFollowing(
-    id?: string | number,
-    options?: Partial<
-      Pick<AccountFollowingFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups' | 'includesHashtags'>
-    >,
+    options?:
+      | string
+      | number
+      | Partial<
+          Pick<AccountFollowingFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups' | 'includesHashtags' | 'id'>
+        >,
   ): AccountFollowingFeed {
     return plainToClassFromExist(new AccountFollowingFeed(this.client), {
-      ...options,
-      id: id || this.client.state.cookieUserId,
+      id: options && typeof options !== 'object' ? options : this.client.state.cookieUserId,
+      ...(typeof options === 'object' ? options : undefined),
     });
   }
 

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -62,10 +62,16 @@ export class FeedFactory {
     });
   }
 
-  public accountFollowing(id?: string | number): AccountFollowingFeed {
-    const feed = new AccountFollowingFeed(this.client);
-    feed.id = id || this.client.state.cookieUserId;
-    return feed;
+  public accountFollowing(
+    id?: string | number,
+    options?: Partial<
+      Pick<AccountFollowingFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups' | 'includesHashtags'>
+    >,
+  ): AccountFollowingFeed {
+    return plainToClassFromExist(new AccountFollowingFeed(this.client), {
+      ...options,
+      id: id || this.client.state.cookieUserId,
+    });
   }
 
   public news(): NewsFeed {

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -52,10 +52,14 @@ import {
 export class FeedFactory {
   constructor(private client: IgApiClient) {}
 
-  public accountFollowers(id?: string | number): AccountFollowersFeed {
-    const feed = new AccountFollowersFeed(this.client);
-    feed.id = id || this.client.state.cookieUserId;
-    return feed;
+  public accountFollowers(
+    id?: string | number,
+    options?: Partial<Pick<AccountFollowersFeed, 'searchSurface' | 'order' | 'query' | 'enableGroups'>>,
+  ): AccountFollowersFeed {
+    return plainToClassFromExist(new AccountFollowersFeed(this.client), {
+      ...options,
+      id: id || this.client.state.cookieUserId,
+    });
   }
 
   public accountFollowing(id?: string | number): AccountFollowingFeed {

--- a/src/feeds/account-followers.feed.ts
+++ b/src/feeds/account-followers.feed.ts
@@ -3,6 +3,14 @@ import { Feed } from '../core/feed';
 import { AccountFollowersFeedResponse, AccountFollowersFeedResponseUsersItem } from '../responses';
 
 export class AccountFollowersFeed extends Feed<AccountFollowersFeedResponse, AccountFollowersFeedResponseUsersItem> {
+  searchSurface?: string;
+  /**
+   * only 'default' seems to work
+   */
+  order?: 'default' = 'default';
+  query = '';
+  enableGroups = true;
+
   id: number | string;
   @Expose()
   private nextMaxId: string;
@@ -17,6 +25,10 @@ export class AccountFollowersFeed extends Feed<AccountFollowersFeedResponse, Acc
       url: `/api/v1/friendships/${this.id}/followers/`,
       qs: {
         max_id: this.nextMaxId,
+        search_surface: this.searchSurface,
+        order: this.order,
+        query: this.query,
+        enable_groups: this.enableGroups,
       },
     });
     this.state = body;

--- a/src/feeds/account-following.feed.ts
+++ b/src/feeds/account-following.feed.ts
@@ -3,6 +3,12 @@ import { Feed } from '../core/feed';
 import { AccountFollowingFeedResponse, AccountFollowingFeedResponseUsersItem } from '../responses';
 
 export class AccountFollowingFeed extends Feed<AccountFollowingFeedResponse, AccountFollowingFeedResponseUsersItem> {
+  searchSurface?: string;
+  order?: 'default' | 'date_followed_latest' | 'date_followed_earliest' = 'default';
+  query = '';
+  enableGroups = true;
+  includesHashtags = true;
+
   id: number | string;
   @Expose()
   private nextMaxId: string;
@@ -18,6 +24,11 @@ export class AccountFollowingFeed extends Feed<AccountFollowingFeedResponse, Acc
       qs: {
         rank_token: this.rankToken,
         max_id: this.nextMaxId,
+        search_surface: this.searchSurface,
+        order: this.order,
+        query: this.query,
+        enable_groups: this.enableGroups,
+        includes_hashtags: this.includesHashtags,
       },
     });
     this.state = body;


### PR DESCRIPTION
This PR adds options to the `accountFollowing` and `accountFollowers` feeds. This is somewhat related to #1290 although there's no ordering valid for `accountFollowers` as it will get ignored.
The other options were probably added in recent versions.