### PR TITLE
Update media.entity.ts

### DIFF
--- a/src/entities/media.entity.ts
+++ b/src/entities/media.entity.ts
@@ -5,7 +5,7 @@ import { MediaEntityOembedResponse } from '../responses';
 export class MediaEntity extends Entity {
   static async oembed(url: string): Promise<MediaEntityOembedResponse> {
     return request({
-      url: 'https://api.instagram.com/oembed/',
+      url: 'https://api.instagram.com/instagram_oembed/',
       json: true,
       qs: {
         url,


### PR DESCRIPTION
The endpoint is changed and the old is deprecated.
https://developers.facebook.com/docs/instagram/oembed