### PR TITLE
fix: no userids in directthread entities

### DIFF
--- a/src/core/entity.factory.ts
+++ b/src/core/entity.factory.ts
@@ -1,14 +1,12 @@
 import { Repository } from './repository';
 import { DirectThreadEntity, ProfileEntity } from '../entities';
+import { DirectThreadFeedResponseThread } from 'src/responses';
 
 export class EntityFactory extends Repository {
-  public directThread(id: string | string[]): DirectThreadEntity {
+  public directThread(threadResp: DirectThreadFeedResponseThread): DirectThreadEntity {
     const thread = new DirectThreadEntity(this.client);
-    if (id instanceof Array) {
-      thread.userIds = id;
-    } else {
-      thread.threadId = id;
-    }
+    thread.userIds = threadResp.users.map(user => user.username);
+    thread.threadId = threadResp.thread_id;
     return thread;
   }
 

--- a/src/feeds/direct-inbox.feed.ts
+++ b/src/feeds/direct-inbox.feed.ts
@@ -1,6 +1,10 @@
 import { Expose } from 'class-transformer';
 import { Feed } from '../core/feed';
-import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
+import {
+  DirectInboxFeedResponse,
+  DirectInboxFeedResponseThreadsItem,
+  DirectThreadFeedResponseThread,
+} from '../responses';
 import { DirectThreadEntity } from '../entities';
 
 export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
@@ -39,6 +43,8 @@ export class DirectInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFe
 
   async records(): Promise<DirectThreadEntity[]> {
     const threads = await this.items();
-    return threads.map(thread => this.client.entity.directThread(thread.thread_id));
+    return threads.map(thread =>
+      this.client.entity.directThread((thread as unknown) as DirectThreadFeedResponseThread),
+    );
   }
 }

--- a/src/feeds/direct-pending.feed.ts
+++ b/src/feeds/direct-pending.feed.ts
@@ -1,6 +1,10 @@
 import { Expose } from 'class-transformer';
 import { Feed } from '../core/feed';
-import { DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem } from '../responses';
+import {
+  DirectInboxFeedResponse,
+  DirectInboxFeedResponseThreadsItem,
+  DirectThreadFeedResponseThread,
+} from '../responses';
 import { DirectThreadEntity } from '../entities';
 
 export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, DirectInboxFeedResponseThreadsItem> {
@@ -39,6 +43,8 @@ export class DirectPendingInboxFeed extends Feed<DirectInboxFeedResponse, Direct
 
   async records(): Promise<DirectThreadEntity[]> {
     const threads = await this.items();
-    return threads.map(thread => this.client.entity.directThread(thread.thread_id));
+    return threads.map(thread =>
+      this.client.entity.directThread((thread as unknown) as DirectThreadFeedResponseThread),
+    );
   }
 }


### PR DESCRIPTION
A very lazy fix to directthread entities not having userIds