### PR TITLE
FIX: image-size 0.7.3 throws error "Module 'fs' cannot be found". Resolved in 0.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chance": "^1.0.18",
     "class-transformer": "^0.3.1",
     "debug": "^4.1.1",
-    "image-size": "^0.7.3",
+    "image-size": "^0.9.7",
     "json-bigint": "^0.3.0",
     "lodash": "^4.17.20",
     "luxon": "^1.12.1",


### PR DESCRIPTION
Package 'image-size' 0.7.3 throws error "Module 'fs' cannot be found". Resolved in 0.9.7