### PR TITLE
Add ability to select carousel media when broadcasting post

### DIFF
--- a/src/entities/direct-thread.entity.ts
+++ b/src/entities/direct-thread.entity.ts
@@ -116,12 +116,12 @@ export class DirectThreadEntity extends Entity {
     });
   }
 
-  public async broadcastPost(mediaId: string) {
+  public async broadcastPost(mediaId: string, carouselMediaId?: string) {
     return await this.broadcast({
       item: 'media_share',
       form: {
         media_id: mediaId,
-        carousel_share_child_media_id: mediaId,
+        carousel_share_child_media_id: carouselMediaId ?? mediaId,
         send_attribution: 'feed_contextual_profile',
         unified_broadcast_format: 1,
       },


### PR DESCRIPTION
The underlying broadcast API allows selecting a child media when a carousel post is shared. This PR exposes that API