### PR TITLE
feature: Add Clips Upload

### DIFF
--- a/src/repositories/media.repository.ts
+++ b/src/repositories/media.repository.ts
@@ -362,7 +362,7 @@ export class MediaRepository extends Repository {
     return body;
   }
 
-  public async configureVideo(options: MediaConfigureTimelineVideoOptions) {
+  public async configureVideo(options: MediaConfigureTimelineVideoOptions, isClips: boolean) {
     const now = DateTime.local().toFormat('yyyy:mm:dd HH:mm:ss');
 
     const form = this.applyConfigureDefaults<MediaConfigureTimelineVideoOptions>(options, {
@@ -388,7 +388,7 @@ export class MediaRepository extends Repository {
     }
 
     const { body } = await this.client.request.send<MediaRepositoryConfigureResponseRootObject>({
-      url: '/api/v1/media/configure/',
+      url: '/api/v1/media/configure' + (isClips ? '_to_clips/' : '/'),
       method: 'POST',
       qs: {
         video: '1',
@@ -682,10 +682,10 @@ export class MediaRepository extends Repository {
    * save a media, or save it to collection if you pass the collection ids in array
    * @param {string} mediaId - The mediaId of the post
    * @param {string[]} [collection_ids] - Optional, The array of collection ids if you want to save the media to a specific collection
-   * Example: 
+   * Example:
    * save("2524149952724070925_1829855275") save media
    * save("2524149952724070925_1829855275", ["17865977635619975"]) save media to 1 collection
-   * save("2524149952724070925_1829855275", ["17865977635619975", "17845997638619928"]) save media to 2 collection 
+   * save("2524149952724070925_1829855275", ["17865977635619975", "17845997638619928"]) save media to 2 collection
    */
   public async save(mediaId: string, collection_ids?: string[]) {
     const { body } = await this.client.request.send({
@@ -795,27 +795,24 @@ export class MediaRepository extends Repository {
     });
     return body;
   }
-  
-  private async storyCountdownAction(
-    countdownId: string | number,
-    action: string,
-  ): Promise<StatusResponse> {
+
+  private async storyCountdownAction(countdownId: string | number, action: string): Promise<StatusResponse> {
     const { body } = await this.client.request.send({
       url: `/api/v1/media/${countdownId}/${action}/`,
       method: 'POST',
       form: this.client.request.sign({
         _csrftoken: this.client.state.cookieCsrfToken,
         _uid: this.client.state.cookieUserId,
-        _uuid: this.client.state.uuid
+        _uuid: this.client.state.uuid,
       }),
     });
     return body;
   }
-  
+
   public async storyCountdownFollow(countdownId: string | number) {
     return this.storyCountdownAction(countdownId, 'follow_story_countdown');
   }
-  
+
   public async storyCountdownUnfollow(countdownId: string | number) {
     return this.storyCountdownAction(countdownId, 'unfollow_story_countdown');
   }

--- a/src/repositories/upload.repository.ts
+++ b/src/repositories/upload.repository.ts
@@ -247,6 +247,9 @@ export class UploadRepository extends Repository {
     if (options.isDirectVoice) {
       ruploadParams.is_direct_voice = '1';
     }
+    if (options.isClipVideo) {
+      ruploadParams.is_clips_video = '1';
+    }
     return ruploadParams;
   }
 }

--- a/src/services/publish.service.ts
+++ b/src/services/publish.service.ts
@@ -158,6 +158,7 @@ export class PublishService extends Repository {
     await Bluebird.try(() =>
       this.regularVideo({
         video: options.video,
+        isClipVideo: options.isClip,
         uploadId,
         ...videoInfo,
       }),
@@ -196,9 +197,13 @@ export class PublishService extends Repository {
       configureOptions.usertags = options.usertags;
     }
 
+    if (typeof options.clipsPreviewToFeed) {
+      configureOptions.clips_share_preview_to_feed = options.clipsPreviewToFeed ? '1' : '0';
+    }
+
     for (let i = 0; i < 6; i++) {
       try {
-        return await this.client.media.configureVideo(configureOptions);
+        return await this.client.media.configureVideo(configureOptions, options.isClip);
       } catch (e) {
         if (i >= 5 || e.response.statusCode >= 400) {
           throw new IgConfigureVideoError(e.response, configureOptions);

--- a/src/types/media.configure-video.options.ts
+++ b/src/types/media.configure-video.options.ts
@@ -16,6 +16,9 @@ export interface MediaConfigureVideoOptions {
   posting_longitude?: string;
   media_latitude?: string;
   media_longitude?: string;
+
+  isClipsVideo?: boolean;
+  clips_share_preview_to_feed?: string;
 }
 
 export interface MediaConfigureTimelineVideoOptions extends MediaConfigureVideoOptions {

--- a/src/types/posting.video.options.ts
+++ b/src/types/posting.video.options.ts
@@ -7,6 +7,8 @@ export interface PostingVideoOptions {
   usertags?: PostingUsertags;
   location?: PostingLocation;
   transcodeDelay?: number;
+  isClip?: boolean;
+  clipsPreviewToFeed?: boolean;
 }
 
 export interface PostingStoryVideoOptions extends PostingStoryOptions {

--- a/src/types/upload.video.options.ts
+++ b/src/types/upload.video.options.ts
@@ -16,6 +16,7 @@ export interface UploadVideoOptions {
   waterfallId?: string;
   uploadName?: string;
   offset?: number;
+  isClipVideo?: boolean;
 }
 
 export interface UploadVideoSegmentInitOptions {


### PR DESCRIPTION
I made a simple change to support clip / reels upload. The usage is same as upload video, but simply add param `isClip` to `true`

```js
const publishResult = await ig.publish.video({
      // read the file into a Buffer
      video: video,
      coverImage: cover,
      isClip: true,
      // i also add option to preview the clips in feed or not
      clipsPreviewToFeed: true
})
```
