### PR TITLE
FEATURE: Added clips timeline and clip upload support.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "class-transformer": "^0.3.1",
         "debug": "^4.1.1",
         "image-size": "^0.7.3",
+        "jsdom": "^23.0.1",
         "json-bigint": "^1.0.0",
         "lodash": "^4.17.20",
         "luxon": "^1.12.1",
@@ -33,6 +34,7 @@
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.26",
+        "@types/jsdom": "^21.1.6",
         "@types/lodash": "^4.14.123",
         "@types/luxon": "^1.12.0",
         "@types/node": "^10.14.5",
@@ -155,6 +157,17 @@
       "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.3.tgz",
       "integrity": "sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw=="
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
@@ -196,6 +209,17 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.8.tgz",
       "integrity": "sha512-7axfYN8SW9pWg78NgenHasSproWQee5rzyPVLC9HpaQSDgNArsnKJD88EaMfi4Pl48AyciO3agYCFqpHS1gLpg=="
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -566,6 +590,17 @@
         "node": ">=4.8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -577,10 +612,22 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -592,6 +639,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -635,6 +687,17 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -917,6 +980,29 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -929,6 +1015,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -954,6 +1052,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1092,6 +1201,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1146,6 +1260,72 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "node_modules/jsdom": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.0.1.tgz",
+      "integrity": "sha512-2i27vgvlUsGEBO9+/kJQRbtqtm+191b5zAZrU/UezVmnC2dlDAFLgDYJvAEi94T4kjsRKkezEtLQTgsNEsW2lQ==",
+      "dependencies": {
+        "cssstyle": "^3.0.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.7",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.14.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -1441,6 +1621,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1550,6 +1735,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -1835,9 +2031,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -1849,6 +2045,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/read-pkg": {
       "version": "4.0.1",
@@ -1966,6 +2167,11 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -2016,6 +2222,11 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -2078,6 +2289,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -2324,6 +2546,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2381,6 +2608,17 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/transducers-js": {
@@ -2598,12 +2836,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-regex-safe": {
@@ -2689,6 +2944,56 @@
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2712,6 +3017,39 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/yallist": {
       "version": "2.1.2",
@@ -2807,6 +3145,17 @@
       "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.3.tgz",
       "integrity": "sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw=="
     },
+    "@types/jsdom": {
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
@@ -2848,6 +3197,14 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.8.tgz",
       "integrity": "sha512-7axfYN8SW9pWg78NgenHasSproWQee5rzyPVLC9HpaQSDgNArsnKJD88EaMfi4Pl48AyciO3agYCFqpHS1gLpg=="
+    },
+    "agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -3151,6 +3508,14 @@
         "which": "^1.2.9"
       }
     },
+    "cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "requires": {
+        "rrweb-cssom": "^0.6.0"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3159,13 +3524,27 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "requires": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      }
+    },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3201,6 +3580,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3415,6 +3799,23 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "requires": {
+        "whatwg-encoding": "^3.1.1"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -3423,6 +3824,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "requires": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
       }
     },
     "husky": {
@@ -3441,6 +3851,14 @@
         "read-pkg": "^4.0.1",
         "run-node": "^1.0.0",
         "slash": "^2.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "ignore": {
@@ -3552,6 +3970,11 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3600,6 +4023,57 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.0.1.tgz",
+      "integrity": "sha512-2i27vgvlUsGEBO9+/kJQRbtqtm+191b5zAZrU/UezVmnC2dlDAFLgDYJvAEi94T4kjsRKkezEtLQTgsNEsW2lQ==",
+      "requires": {
+        "cssstyle": "^3.0.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.7",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.14.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+          "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.2.0",
+            "url-parse": "^1.5.3"
+          }
+        }
+      }
     },
     "json-bigint": {
       "version": "1.0.0",
@@ -3839,6 +4313,11 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -3915,6 +4394,14 @@
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "requires": {
+        "entities": "^4.4.0"
       }
     },
     "path-exists": {
@@ -4139,14 +4626,19 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "read-pkg": {
       "version": "4.0.1",
@@ -4245,6 +4737,11 @@
         "lodash": "^4.17.19"
       }
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -4281,6 +4778,11 @@
         "glob": "^7.1.3"
       }
     },
+    "rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -4316,6 +4818,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -4516,6 +5026,11 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -4564,6 +5079,14 @@
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "requires": {
+        "punycode": "^2.3.1"
       }
     },
     "transducers-js": {
@@ -4715,12 +5238,26 @@
       "dev": true,
       "optional": true
     },
+    "universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-regex-safe": {
@@ -4787,6 +5324,41 @@
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "requires": {
+        "iconv-lite": "0.6.3"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+    },
+    "whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "requires": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4807,6 +5379,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "requires": {}
+    },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/dilame/instagram-private-api",
   "scripts": {
+    "tests": "ts-node ./tests.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json -c tslint.json",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "class-transformer": "^0.3.1",
     "debug": "^4.1.1",
     "image-size": "^0.7.3",
+    "jsdom": "^23.0.1",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.20",
     "luxon": "^1.12.1",
@@ -68,6 +69,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.26",
+    "@types/jsdom": "^21.1.6",
     "@types/lodash": "^4.14.123",
     "@types/luxon": "^1.12.0",
     "@types/node": "^10.14.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/dilame/instagram-private-api",
   "scripts": {
-    "tests": "ts-node ./tests.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json -c tslint.json",

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -30,6 +30,7 @@ import {
   IgtvChannelFeed,
   LikedFeed,
   TopicalExploreFeed,
+  ClipsFeed,
 } from '../feeds';
 import { DirectInboxFeedResponseThreadsItem } from '../responses';
 import { plainToClassFromExist } from 'class-transformer';
@@ -323,5 +324,11 @@ export class FeedFactory {
     options: Partial<Pick<TopicalExploreFeed, 'sessionId' | 'clusterId' | 'lat' | 'lng' | 'module'>> = {},
   ): TopicalExploreFeed {
     return plainToClassFromExist(new TopicalExploreFeed(this.client), options);
+  }
+
+  public clips(id: string | number) {
+    return plainToClassFromExist(new ClipsFeed(this.client), {
+      targetUserId: id,
+    });
   }
 }

--- a/src/core/feed.factory.ts
+++ b/src/core/feed.factory.ts
@@ -326,9 +326,8 @@ export class FeedFactory {
     return plainToClassFromExist(new TopicalExploreFeed(this.client), options);
   }
 
-  public clips(id: string | number) {
-    return plainToClassFromExist(new ClipsFeed(this.client), {
-      targetUserId: id,
-    });
+  public clipsFeed(): ClipsFeed {
+    const feed = new ClipsFeed(this.client);
+    return feed;
   }
 }

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -56,7 +56,11 @@ export class Request {
     return resolveWithFullResponse ? response : response.body;
   }
 
-  public async send<T = any>(userOptions: Options, onlyCheckHttpStatus?: boolean): Promise<IgResponse<T>> {
+  public async send<T = any>(
+    userOptions: Options,
+    onlyCheckHttpStatus?: boolean,
+    transform?: boolean,
+  ): Promise<IgResponse<T>> {
     const options = defaultsDeep(
       userOptions,
       {
@@ -64,7 +68,7 @@ export class Request {
         resolveWithFullResponse: true,
         proxy: this.client.state.proxyUrl,
         simple: false,
-        transform: Request.requestTransform,
+        transform: transform || Request.requestTransform,
         jar: this.client.state.cookieJar,
         strictSSL: false,
         gzip: true,

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -68,7 +68,7 @@ export class Request {
         resolveWithFullResponse: true,
         proxy: this.client.state.proxyUrl,
         simple: false,
-        transform: transform || Request.requestTransform,
+        transform: transform == false ? undefined : Request.requestTransform,
         jar: this.client.state.cookieJar,
         strictSSL: false,
         gzip: true,

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -78,6 +78,7 @@ export class State {
   build: string;
   uuid: string;
   phoneId: string;
+  fb_dtsg: string;
   /**
    * Google Play Advertising ID.
    *
@@ -226,7 +227,7 @@ export class State {
     const obj = typeof state === 'string' ? JSON.parse(state) : state;
     if (typeof obj !== 'object') {
       State.stateDebug(`State deserialization failed, obj is of type ${typeof obj} (object expected)`);
-      throw new TypeError('State isn\'t an object or serialized JSON');
+      throw new TypeError("State isn't an object or serialized JSON");
     }
     State.stateDebug(`Deserializing ${Object.keys(obj).join(', ')}`);
     if (obj.constants) {

--- a/src/feeds/clips.feed.ts
+++ b/src/feeds/clips.feed.ts
@@ -15,7 +15,7 @@ export class ClipsFeed extends Feed<ClipsFeedResponseRootObject, ClipsFeedRespon
 
   async request(): Promise<ClipsFeedResponseRootObject> {
     const { body } = await this.client.request.send({
-      url: '/api/v1/clips/user',
+      url: '/api/v1/clips/user/',
       form: {
         target_user_id: this.targetUserId,
         max_id: this.maxId,

--- a/src/feeds/clips.feed.ts
+++ b/src/feeds/clips.feed.ts
@@ -1,0 +1,36 @@
+import { Feed } from '../core/feed';
+import { Expose } from 'class-transformer';
+import { ClipsFeedResponseItemsItem, ClipsFeedResponseRootObject } from '../responses/clips.feed.response';
+
+export class ClipsFeed extends Feed<ClipsFeedResponseRootObject, ClipsFeedResponseItemsItem> {
+  targetUserId: string;
+
+  @Expose()
+  private maxId: string;
+
+  protected set state(response: ClipsFeedResponseRootObject) {
+    this.moreAvailable = response.paging_info.more_available;
+    this.maxId = response.paging_info.max_id;
+  }
+
+  async request(): Promise<ClipsFeedResponseRootObject> {
+    const { body } = await this.client.request.send({
+      url: '/api/v1/clips/user',
+      form: {
+        target_user_id: this.targetUserId,
+        max_id: this.maxId,
+        _csrftoken: this.client.state.cookieCsrfToken,
+        _uuid: this.client.state.uuid,
+      },
+      method: 'POST',
+    });
+
+    this.state = body;
+    return body;
+  }
+
+  async items(): Promise<ClipsFeedResponseItemsItem[]> {
+    const res = await this.request();
+    return res.items;
+  }
+}

--- a/src/feeds/clips.feed.ts
+++ b/src/feeds/clips.feed.ts
@@ -1,23 +1,46 @@
 import { Expose } from 'class-transformer';
 import { Feed } from '../core/feed';
-import { ClipsFeedResponse, TimelineFeedResponseMedia_or_ad } from '../responses';
+import { ClipsFeedResponse, ClipsFeedVariables, TimelineFeedResponseMedia_or_ad } from '../responses';
 
 export class ClipsFeed extends Feed<ClipsFeedResponse, TimelineFeedResponseMedia_or_ad> {
   tag: string;
   @Expose()
+  private feedVariables: ClipsFeedVariables;
+
   set state(body) {
     this.moreAvailable = body.data.xdt_api__v1__clips__home__connection_v2.page_info.has_next_page;
+    this.feedVariables = {
+      after: body.data.xdt_api__v1__clips__home__connection_v2.page_info.end_cursor,
+      before: null,
+      data: {
+        container_module: 'clips_tab_desktop_page',
+        seen_reels: body.data.xdt_api__v1__clips__home__connection_v2.edges.map(i => {
+          return { id: i.node.media.id };
+        }),
+      },
+      first: 10,
+      last: null,
+    };
   }
 
   async request() {
-    const form = {
+    let form = {
       fb_dtsg: this.client.state.fb_dtsg,
       fb_api_caller_class: 'RelayModern',
       fb_api_req_friendly_name: 'PolarisClipsTabDesktopContainerQuery',
-      variables: JSON.stringify({ data: { container_module: 'clips_tab_desktop_page' } }),
       server_timestamps: true,
       doc_id: '6846808792076706',
     };
+
+    if (this.feedVariables) {
+      form = Object.assign(form, {
+        variables: JSON.stringify(this.feedVariables),
+      });
+    } else {
+      form = Object.assign(form, {
+        variables: JSON.stringify({ data: { container_module: 'clips_tab_desktop_page' } }),
+      });
+    }
 
     const { body } = await this.client.request.send<ClipsFeedResponse>(
       {

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -28,3 +28,4 @@ export * from './igtv.browse.feed';
 export * from './igtv.channel.feed';
 export * from './liked.feed';
 export * from './topical-explore.feed';
+export * from './clips.feed';

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -87,7 +87,7 @@ export class AccountRepository extends Repository {
         headers: {},
       },
       true,
-      null, // disable transform to json because we are getting html
+      false, // disable transform to json because we are getting html
     );
 
     const dom = new JSDOM(body);

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -85,9 +85,9 @@ export class AccountRepository extends Repository {
         url: 'null',
         method: 'GET',
         headers: {},
-        transform: null,
       },
       true,
+      null, // disable transform to json because we are getting html
     );
 
     const dom = new JSDOM(body);

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -19,6 +19,7 @@ import { IgSignupBlockError } from '../errors/ig-signup-block.error';
 import Bluebird = require('bluebird');
 import debug from 'debug';
 import * as crypto from 'crypto';
+import { JSDOM } from 'jsdom';
 
 export class AccountRepository extends Repository {
   private static accountDebug = debug('ig:account');
@@ -26,7 +27,7 @@ export class AccountRepository extends Repository {
     if (!this.client.state.passwordEncryptionPubKey) {
       await this.client.qe.syncLoginExperiments();
     }
-    const {encrypted, time} = this.encryptPassword(password);
+    const { encrypted, time } = this.encryptPassword(password);
     const response = await Bluebird.try(() =>
       this.client.request.send<AccountRepositoryLoginResponseRootObject>({
         method: 'POST',
@@ -64,6 +65,8 @@ export class AccountRepository extends Repository {
         }
       }
     });
+
+    this.client.state.fb_dtsg = await this.getDtsg();
     return response.body.logged_in_user;
   }
 
@@ -76,14 +79,37 @@ export class AccountRepository extends Repository {
     return `2${sum}`;
   }
 
-  public encryptPassword(password: string): { time: string, encrypted: string } {
+  private async getDtsg() {
+    const { body } = await this.client.request.send(
+      {
+        url: 'null',
+        method: 'GET',
+        headers: {},
+        transform: null,
+      },
+      true,
+    );
+
+    const dom = new JSDOM(body);
+    const unparsedParams = dom.window.document.querySelector('#__eqmc').innerHTML;
+
+    const params = JSON.parse(unparsedParams);
+    const fb_dtsg = params.f;
+
+    return fb_dtsg;
+  }
+
+  public encryptPassword(password: string): { time: string; encrypted: string } {
     const randKey = crypto.randomBytes(32);
     const iv = crypto.randomBytes(12);
-    const rsaEncrypted = crypto.publicEncrypt({
-      key: Buffer.from(this.client.state.passwordEncryptionPubKey, 'base64').toString(),
-      // @ts-ignore
-      padding: crypto.constants.RSA_PKCS1_PADDING,
-    }, randKey);
+    const rsaEncrypted = crypto.publicEncrypt(
+      {
+        key: Buffer.from(this.client.state.passwordEncryptionPubKey, 'base64').toString(),
+        // @ts-ignore
+        padding: crypto.constants.RSA_PKCS1_PADDING,
+      },
+      randKey,
+    );
     const cipher = crypto.createCipheriv('aes-256-gcm', randKey, iv);
     const time = Math.floor(Date.now() / 1000).toString();
     cipher.setAAD(Buffer.from(time));
@@ -97,8 +123,10 @@ export class AccountRepository extends Repository {
         Buffer.from([1, this.client.state.passwordEncryptionKeyId]),
         iv,
         sizeBuffer,
-        rsaEncrypted, authTag, aesEncrypted])
-        .toString('base64'),
+        rsaEncrypted,
+        authTag,
+        aesEncrypted,
+      ]).toString('base64'),
     };
   }
 

--- a/src/repositories/media.repository.ts
+++ b/src/repositories/media.repository.ts
@@ -362,7 +362,7 @@ export class MediaRepository extends Repository {
     return body;
   }
 
-  public async configureVideo(options: MediaConfigureTimelineVideoOptions) {
+  public async configureVideo(options: MediaConfigureTimelineVideoOptions, isClipVideo: boolean) {
     const now = DateTime.local().toFormat('yyyy:mm:dd HH:mm:ss');
 
     const form = this.applyConfigureDefaults<MediaConfigureTimelineVideoOptions>(options, {
@@ -388,7 +388,7 @@ export class MediaRepository extends Repository {
     }
 
     const { body } = await this.client.request.send<MediaRepositoryConfigureResponseRootObject>({
-      url: '/api/v1/media/configure/',
+      url: '/api/v1/media/configure' + (isClipVideo ? '_to_clips/' : '/'),
       method: 'POST',
       qs: {
         video: '1',
@@ -682,10 +682,10 @@ export class MediaRepository extends Repository {
    * save a media, or save it to collection if you pass the collection ids in array
    * @param {string} mediaId - The mediaId of the post
    * @param {string[]} [collection_ids] - Optional, The array of collection ids if you want to save the media to a specific collection
-   * Example: 
+   * Example:
    * save("2524149952724070925_1829855275") save media
    * save("2524149952724070925_1829855275", ["17865977635619975"]) save media to 1 collection
-   * save("2524149952724070925_1829855275", ["17865977635619975", "17845997638619928"]) save media to 2 collection 
+   * save("2524149952724070925_1829855275", ["17865977635619975", "17845997638619928"]) save media to 2 collection
    */
   public async save(mediaId: string, collection_ids?: string[]) {
     const { body } = await this.client.request.send({
@@ -795,27 +795,24 @@ export class MediaRepository extends Repository {
     });
     return body;
   }
-  
-  private async storyCountdownAction(
-    countdownId: string | number,
-    action: string,
-  ): Promise<StatusResponse> {
+
+  private async storyCountdownAction(countdownId: string | number, action: string): Promise<StatusResponse> {
     const { body } = await this.client.request.send({
       url: `/api/v1/media/${countdownId}/${action}/`,
       method: 'POST',
       form: this.client.request.sign({
         _csrftoken: this.client.state.cookieCsrfToken,
         _uid: this.client.state.cookieUserId,
-        _uuid: this.client.state.uuid
+        _uuid: this.client.state.uuid,
       }),
     });
     return body;
   }
-  
+
   public async storyCountdownFollow(countdownId: string | number) {
     return this.storyCountdownAction(countdownId, 'follow_story_countdown');
   }
-  
+
   public async storyCountdownUnfollow(countdownId: string | number) {
     return this.storyCountdownAction(countdownId, 'unfollow_story_countdown');
   }

--- a/src/repositories/upload.repository.ts
+++ b/src/repositories/upload.repository.ts
@@ -247,6 +247,9 @@ export class UploadRepository extends Repository {
     if (options.isDirectVoice) {
       ruploadParams.is_direct_voice = '1';
     }
+    if (options.isClipVideo) {
+      ruploadParams.is_clips_video = '1';
+    }
     return ruploadParams;
   }
 }

--- a/src/responses/clips.feed.response.ts
+++ b/src/responses/clips.feed.response.ts
@@ -1,0 +1,215 @@
+export interface ClipsFeedResponseRootObject {
+  id: string;
+  items: ClipsFeedResponseItemsItem[];
+  paging_info: {
+    more_available: boolean;
+    max_id: string;
+  };
+  status: string;
+}
+
+export interface ClipsFeedResponseItemsItem {
+  media: {
+    taken_at: number;
+    pk: string;
+    id: string;
+    device_timestamp: number | string;
+    media_type: number;
+    code: string;
+    client_cache_key: string;
+    filter_type: number;
+    is_unified_video: boolean;
+    should_request_ads: boolean;
+    caption_is_edited: boolean;
+    like_and_view_counts_disabled: boolean;
+    commerciality_status: string;
+    is_paid_partnership: boolean;
+    is_visual_reply_commenter_notice_enabled: boolean;
+    has_delayed_metadata: boolean;
+    comment_likes_enabled: boolean;
+    comment_threading_enabled: boolean;
+    has_more_comments: boolean;
+    next_max_id: string;
+    max_num_visible_preview_comments: number;
+    preview_comments: ClipsFeedResponsePreviewCommentsItem[];
+    can_view_more_preview_comments: boolean;
+    comment_count: number;
+    hide_view_all_comment_entrypoint: boolean;
+    image_versions2: ClipsFeedResponseImage_versions2;
+    original_width: number;
+    original_height: number;
+    user: ClipsFeedResponseUser_dict;
+    can_viewer_reshare: boolean;
+    like_count: number;
+    photo_of_you: boolean;
+    is_organic_product_tagging_eligible: boolean;
+    can_see_insights_as_brand: boolean;
+    video_subtitles_confidence: string;
+    is_dash_eligible: number;
+    video_dash_manifest: string;
+    video_codec: string;
+    number_of_qualities: number;
+    video_versions: ClipsFeedResponseVideoVersionsItem[];
+    has_audio: boolean;
+    video_duration: number;
+    view_count: number;
+    play_count: number;
+    caption: ClipsFeedResponseCaption;
+    comment_inform_treatment: {
+      should_have_inform_treatment: boolean;
+      text: string;
+      url: string | null;
+      action_type: string | null;
+    };
+    sharing_friction_info: {
+      should_have_sharing_friction: boolean;
+      bloks_app_url: string | null;
+      sharing_friction_payload: string | null;
+    };
+    can_viewer_save: boolean;
+    is_in_profile_grid: boolean;
+    profile_grid_control_enabled: boolean;
+    organic_tracking_token: string;
+    has_shared_to_fb: boolean;
+    product_type: string;
+    deleted_reason: number;
+    integrity_review_decision: string;
+    logging_info_token: string;
+  };
+}
+
+export interface ClipsFeedResponsePreviewCommentsItem {
+  pk: string;
+  user_id: number;
+  text: string;
+  type: number;
+  created_at: number;
+  created_at_utc: number;
+  content_type: string;
+  status: string;
+  bit_flags: number;
+  did_report_as_spam: boolean;
+  share_enabled: boolean;
+  user: ClipsFeedResponseUser;
+  is_covered: boolean;
+  media_id: string;
+  has_translation: boolean;
+  private_reply_status: string;
+}
+
+export interface ClipsFeedResponseUser {
+  pk: number;
+  username: string;
+  full_name: string;
+  is_private: boolean;
+  profile_pic_url: string;
+  profile_pic_id?: string;
+  is_verified: boolean;
+}
+
+export interface ClipsFeedResponseFriendship_status {
+  following: boolean;
+  outgoing_request: boolean;
+  is_bestie: boolean;
+  is_restricted: boolean;
+  followed_by?: boolean;
+  blocking?: boolean;
+  muting?: boolean;
+  is_private?: boolean;
+  incoming_request?: boolean;
+}
+
+export interface ClipsFeedResponseImage_versions2 {
+  candidates: ClipsFeedResponseCandidatesItem[];
+  additional_candidates: ClipsFeedResponseAdditional_candidates;
+  animated_thumbnail_spritesheet_info_candidates: ClipsFeedResponseAnimated_thumbnail_spritesheet_info_candidates;
+}
+
+export interface ClipsFeedResponseCandidatesItem {
+  width: number;
+  height: number;
+  url: string;
+  scans_profile: string;
+}
+
+export interface ClipsFeedResponseAdditional_candidates {
+  igtv_first_frame: ClipsFeedResponseIgtv_first_frame;
+  first_frame: ClipsFeedResponseFirst_frame;
+}
+
+export interface ClipsFeedResponseIgtv_first_frame {
+  width: number;
+  height: number;
+  url: string;
+  scans_profile: string;
+}
+
+export interface ClipsFeedResponseFirst_frame {
+  width: number;
+  height: number;
+  url: string;
+  scans_profile: string;
+}
+
+export interface ClipsFeedResponseAnimated_thumbnail_spritesheet_info_candidates {
+  default: {
+    video_length: number;
+    thumbnail_width: number;
+    thumbnail_height: number;
+    thumbnail_duration: string;
+    sprite_urls: string[];
+    thumbnails_per_row: number;
+    total_thumbnail_num_per_sprite: number;
+    max_thumbnails_per_sprite: number;
+    sprite_width: number;
+    sprite_height: number;
+    rendered_width: number;
+    file_size_kb: number;
+  };
+}
+
+export interface ClipsFeedResponseUser_dict {
+  pk: number;
+  username: string;
+  full_name: string;
+  is_private: boolean;
+  profile_pic_url: string;
+  profile_pic_id: string;
+  friendship_status: ClipsFeedResponseFriendship_status;
+  is_verified: boolean;
+  has_anonymous_profile_picture: boolean;
+  is_unpublished: boolean;
+  is_favorite: boolean;
+  has_highlight_reels: boolean;
+  transparency_product_enabled: boolean;
+  account_badges: {}[];
+  fan_club_info: {
+    fan_club_id: string;
+    fan_club_name: string;
+  };
+}
+
+export interface ClipsFeedResponseVideoVersionsItem {
+  type: number;
+  width: number;
+  height: number;
+  url: string;
+  id: string;
+}
+
+export interface ClipsFeedResponseCaption {
+  pk: string;
+  user_id: number;
+  text: string;
+  type: number;
+  created_at: number;
+  created_at_utc: number;
+  content_type: string;
+  status: string;
+  bit_flags: number;
+  user: ClipsFeedResponseUser;
+  did_report_as_spam: boolean;
+  share_enabled: boolean;
+  media_id: string;
+  has_translation: boolean;
+}

--- a/src/responses/clips.feed.response.ts
+++ b/src/responses/clips.feed.response.ts
@@ -1,215 +1,26 @@
-export interface ClipsFeedResponseRootObject {
-  id: string;
-  items: ClipsFeedResponseItemsItem[];
-  paging_info: {
-    more_available: boolean;
-    max_id: string;
-  };
-  status: string;
-}
+import { TimelineFeedResponseMedia_or_ad } from './timeline.feed.response';
 
-export interface ClipsFeedResponseItemsItem {
-  media: {
-    taken_at: number;
-    pk: string;
-    id: string;
-    device_timestamp: number | string;
-    media_type: number;
-    code: string;
-    client_cache_key: string;
-    filter_type: number;
-    is_unified_video: boolean;
-    should_request_ads: boolean;
-    caption_is_edited: boolean;
-    like_and_view_counts_disabled: boolean;
-    commerciality_status: string;
-    is_paid_partnership: boolean;
-    is_visual_reply_commenter_notice_enabled: boolean;
-    has_delayed_metadata: boolean;
-    comment_likes_enabled: boolean;
-    comment_threading_enabled: boolean;
-    has_more_comments: boolean;
-    next_max_id: string;
-    max_num_visible_preview_comments: number;
-    preview_comments: ClipsFeedResponsePreviewCommentsItem[];
-    can_view_more_preview_comments: boolean;
-    comment_count: number;
-    hide_view_all_comment_entrypoint: boolean;
-    image_versions2: ClipsFeedResponseImage_versions2;
-    original_width: number;
-    original_height: number;
-    user: ClipsFeedResponseUser_dict;
-    can_viewer_reshare: boolean;
-    like_count: number;
-    photo_of_you: boolean;
-    is_organic_product_tagging_eligible: boolean;
-    can_see_insights_as_brand: boolean;
-    video_subtitles_confidence: string;
-    is_dash_eligible: number;
-    video_dash_manifest: string;
-    video_codec: string;
-    number_of_qualities: number;
-    video_versions: ClipsFeedResponseVideoVersionsItem[];
-    has_audio: boolean;
-    video_duration: number;
-    view_count: number;
-    play_count: number;
-    caption: ClipsFeedResponseCaption;
-    comment_inform_treatment: {
-      should_have_inform_treatment: boolean;
-      text: string;
-      url: string | null;
-      action_type: string | null;
+export interface ClipsFeedResponse {
+  data: {
+    xdt_api__v1__clips__home__connection_v2: {
+      edges: ClipsFeedResponseFeedItemsItem[];
+      page_info: {
+        end_cursor: string;
+        has_next_page: boolean;
+        has_previous_page: boolean;
+        start_cursor: string | null;
+      };
     };
-    sharing_friction_info: {
-      should_have_sharing_friction: boolean;
-      bloks_app_url: string | null;
-      sharing_friction_payload: string | null;
-    };
-    can_viewer_save: boolean;
-    is_in_profile_grid: boolean;
-    profile_grid_control_enabled: boolean;
-    organic_tracking_token: string;
-    has_shared_to_fb: boolean;
-    product_type: string;
-    deleted_reason: number;
-    integrity_review_decision: string;
-    logging_info_token: string;
+  };
+  extensions: {
+    is_final: boolean;
   };
 }
 
-export interface ClipsFeedResponsePreviewCommentsItem {
-  pk: string;
-  user_id: number;
-  text: string;
-  type: number;
-  created_at: number;
-  created_at_utc: number;
-  content_type: string;
-  status: string;
-  bit_flags: number;
-  did_report_as_spam: boolean;
-  share_enabled: boolean;
-  user: ClipsFeedResponseUser;
-  is_covered: boolean;
-  media_id: string;
-  has_translation: boolean;
-  private_reply_status: string;
-}
-
-export interface ClipsFeedResponseUser {
-  pk: number;
-  username: string;
-  full_name: string;
-  is_private: boolean;
-  profile_pic_url: string;
-  profile_pic_id?: string;
-  is_verified: boolean;
-}
-
-export interface ClipsFeedResponseFriendship_status {
-  following: boolean;
-  outgoing_request: boolean;
-  is_bestie: boolean;
-  is_restricted: boolean;
-  followed_by?: boolean;
-  blocking?: boolean;
-  muting?: boolean;
-  is_private?: boolean;
-  incoming_request?: boolean;
-}
-
-export interface ClipsFeedResponseImage_versions2 {
-  candidates: ClipsFeedResponseCandidatesItem[];
-  additional_candidates: ClipsFeedResponseAdditional_candidates;
-  animated_thumbnail_spritesheet_info_candidates: ClipsFeedResponseAnimated_thumbnail_spritesheet_info_candidates;
-}
-
-export interface ClipsFeedResponseCandidatesItem {
-  width: number;
-  height: number;
-  url: string;
-  scans_profile: string;
-}
-
-export interface ClipsFeedResponseAdditional_candidates {
-  igtv_first_frame: ClipsFeedResponseIgtv_first_frame;
-  first_frame: ClipsFeedResponseFirst_frame;
-}
-
-export interface ClipsFeedResponseIgtv_first_frame {
-  width: number;
-  height: number;
-  url: string;
-  scans_profile: string;
-}
-
-export interface ClipsFeedResponseFirst_frame {
-  width: number;
-  height: number;
-  url: string;
-  scans_profile: string;
-}
-
-export interface ClipsFeedResponseAnimated_thumbnail_spritesheet_info_candidates {
-  default: {
-    video_length: number;
-    thumbnail_width: number;
-    thumbnail_height: number;
-    thumbnail_duration: string;
-    sprite_urls: string[];
-    thumbnails_per_row: number;
-    total_thumbnail_num_per_sprite: number;
-    max_thumbnails_per_sprite: number;
-    sprite_width: number;
-    sprite_height: number;
-    rendered_width: number;
-    file_size_kb: number;
+export interface ClipsFeedResponseFeedItemsItem {
+  node: {
+    media: TimelineFeedResponseMedia_or_ad;
+    __typename: string;
   };
-}
-
-export interface ClipsFeedResponseUser_dict {
-  pk: number;
-  username: string;
-  full_name: string;
-  is_private: boolean;
-  profile_pic_url: string;
-  profile_pic_id: string;
-  friendship_status: ClipsFeedResponseFriendship_status;
-  is_verified: boolean;
-  has_anonymous_profile_picture: boolean;
-  is_unpublished: boolean;
-  is_favorite: boolean;
-  has_highlight_reels: boolean;
-  transparency_product_enabled: boolean;
-  account_badges: {}[];
-  fan_club_info: {
-    fan_club_id: string;
-    fan_club_name: string;
-  };
-}
-
-export interface ClipsFeedResponseVideoVersionsItem {
-  type: number;
-  width: number;
-  height: number;
-  url: string;
-  id: string;
-}
-
-export interface ClipsFeedResponseCaption {
-  pk: string;
-  user_id: number;
-  text: string;
-  type: number;
-  created_at: number;
-  created_at_utc: number;
-  content_type: string;
-  status: string;
-  bit_flags: number;
-  user: ClipsFeedResponseUser;
-  did_report_as_spam: boolean;
-  share_enabled: boolean;
-  media_id: string;
-  has_translation: boolean;
+  cursor: string;
 }

--- a/src/responses/clips.feed.response.ts
+++ b/src/responses/clips.feed.response.ts
@@ -24,3 +24,16 @@ export interface ClipsFeedResponseFeedItemsItem {
   };
   cursor: string;
 }
+
+export interface ClipsFeedVariables {
+  after: string;
+  before: null;
+  data: {
+    container_module: 'clips_tab_desktop_page';
+    seen_reels: {
+      id: string;
+    }[];
+  };
+  first: number;
+  last: null;
+}

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -101,3 +101,4 @@ export * from './igtv.channel.feed.response';
 export * from './igtv.search.response';
 export * from './liked.feed.response';
 export * from './topical-explore.feed.response';
+export * from './clips.feed.response';

--- a/src/services/publish.service.ts
+++ b/src/services/publish.service.ts
@@ -158,6 +158,7 @@ export class PublishService extends Repository {
     await Bluebird.try(() =>
       this.regularVideo({
         video: options.video,
+        isClipVideo: options.isClipVideo,
         uploadId,
         ...videoInfo,
       }),
@@ -198,7 +199,7 @@ export class PublishService extends Repository {
 
     for (let i = 0; i < 6; i++) {
       try {
-        return await this.client.media.configureVideo(configureOptions);
+        return await this.client.media.configureVideo(configureOptions, options.isClipVideo);
       } catch (e) {
         if (i >= 5 || e.response.statusCode >= 400) {
           throw new IgConfigureVideoError(e.response, configureOptions);

--- a/src/types/media.configure-video.options.ts
+++ b/src/types/media.configure-video.options.ts
@@ -16,6 +16,8 @@ export interface MediaConfigureVideoOptions {
   posting_longitude?: string;
   media_latitude?: string;
   media_longitude?: string;
+
+  isClipVideo?: boolean;
 }
 
 export interface MediaConfigureTimelineVideoOptions extends MediaConfigureVideoOptions {

--- a/src/types/posting.video.options.ts
+++ b/src/types/posting.video.options.ts
@@ -7,6 +7,7 @@ export interface PostingVideoOptions {
   usertags?: PostingUsertags;
   location?: PostingLocation;
   transcodeDelay?: number;
+  isClipVideo?: boolean;
 }
 
 export interface PostingStoryVideoOptions extends PostingStoryOptions {

--- a/src/types/upload.video.options.ts
+++ b/src/types/upload.video.options.ts
@@ -16,6 +16,7 @@ export interface UploadVideoOptions {
   waterfallId?: string;
   uploadName?: string;
   offset?: number;
+  isClipVideo?: boolean;
 }
 
 export interface UploadVideoSegmentInitOptions {


### PR DESCRIPTION
I added the ability to fetch instagram reels (clips) with the graphql API and jsdom to get a needed header called fb_dtsg. The first two commits have been voided and are made up into the third.

How to get the clips timeline:

```
const feed = client.feed.clipsFeed();
const items = await feed.items();
const isMoreAvailable = feed.isMoreAvailable();
```

How to upload clips:

```
await client.publish.video({
  coverImage,
  video,
  isClipVideo: true,
});
```