### PR TITLE
BUG: Fixed IG Accounts without a Facebook account failing login due to 400 Bad Request

### DIFF
--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -114,17 +114,15 @@ export class AccountRepository extends Repository {
       trustThisDevice: '1',
       verificationMethod: '1',
     });
-    const { body } = await this.client.request.send<AccountRepositoryLoginResponseLogged_in_user>({
-      url: '/api/v1/accounts/two_factor_login/',
+    const { body } = await this.client.request.send({
+      url: '/api/v1/web/accounts/login/ajax/two_factor/',
       method: 'POST',
       form: this.client.request.sign({
-        verification_code: options.verificationCode,
         _csrftoken: this.client.state.cookieCsrfToken,
-        two_factor_identifier: options.twoFactorIdentifier,
+        identifier: options.twoFactorIdentifier,
+        verificationCode: options.verificationCode,
         username: options.username,
-        trust_this_device: options.trustThisDevice,
-        guid: this.client.state.uuid,
-        device_id: this.client.state.deviceId,
+        trust_signal: options.trustThisDevice === '1' ? 'true' : 'false',
         verification_method: options.verificationMethod,
       }),
     });


### PR DESCRIPTION
File changed: `repositories/account.repository.js:19`

Previously with the endpoint `/api/v1/accounts/login` Instagram accounts not associated with a Facebook account would receive this error:

```
400 Bad Request; The username you entered doesn't appear to belong to an account. Please check your username and try again.
```

After looking at the network logs of Instagram I decided to try switching the endpoint to `/api/v1/web/accounts/login/ajax/` and that seemed to do the trick. Also tested that the new endpoint is compatible with Instagram accounts that **have** Facebook connections.

EDIT: I added a commit to convert the 2FA function in the `account` repository to use the web API as well. Seems like there's some security check to make sure the login and 2fa requests  come from the same platform. Also, if the user doesn't have a  facebook account associated with their Instagram account, I don't think SMS will work here. I had to use an authenticator app to 2FA. Should we add this to the documentation?

~~Question, for some reason the twoFactorLogin function hangs sometimes, but it still does a successful 2FA as my next login is trusted. Confused on why this happens and hoping we can get some clarity on why so this PR can be merged.~~
^ Disregard, issue with my express route.