### PR TITLE
fix: check more error cases when login

### DIFF
--- a/src/errors/ig-account-suspended.error.ts
+++ b/src/errors/ig-account-suspended.error.ts
@@ -1,0 +1,7 @@
+import { IgClientError } from './ig-client.error';
+
+export class IgAccountSuspendedError extends IgClientError {
+  constructor() {
+    super('Instagram account is suspended');
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -24,3 +24,4 @@ export * from './ig-user-id-not-found.error';
 export * from './ig-upload-video-error';
 export * from './ig-user-has-logged-out.error';
 export * from './ig-configure-video-error';
+export * from './ig-account-suspended.error';

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -10,11 +10,12 @@ import {
 import {
   IgLoginBadPasswordError,
   IgLoginInvalidUserError,
+  IgAccountSuspendedError,
   IgLoginTwoFactorRequiredError,
   IgResponseError,
 } from '../errors';
 import { IgResponse, AccountEditProfileOptions, AccountTwoFactorLoginOptions } from '../types';
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep, has } from 'lodash';
 import { IgSignupBlockError } from '../errors/ig-signup-block.error';
 import Bluebird = require('bluebird');
 import debug from 'debug';
@@ -26,7 +27,7 @@ export class AccountRepository extends Repository {
     if (!this.client.state.passwordEncryptionPubKey) {
       await this.client.qe.syncLoginExperiments();
     }
-    const {encrypted, time} = this.encryptPassword(password);
+    const { encrypted, time } = this.encryptPassword(password);
     const response = await Bluebird.try(() =>
       this.client.request.send<AccountRepositoryLoginResponseRootObject>({
         method: 'POST',
@@ -52,6 +53,17 @@ export class AccountRepository extends Repository {
         );
         throw new IgLoginTwoFactorRequiredError(error.response as IgResponse<AccountRepositoryLoginErrorResponse>);
       }
+
+      // Invalid username
+      if (error.response.body.error_title === 'Incorrect username') {
+        throw new IgLoginInvalidUserError(error.response as IgResponse<AccountRepositoryLoginErrorResponse>);
+      }
+
+      // Invalid password
+      if (error.response.body.error_title === 'Username Not Found') {
+        throw new IgLoginBadPasswordError(error.response as IgResponse<AccountRepositoryLoginErrorResponse>);
+      }
+
       switch (error.response.body.error_type) {
         case 'bad_password': {
           throw new IgLoginBadPasswordError(error.response as IgResponse<AccountRepositoryLoginErrorResponse>);
@@ -64,6 +76,12 @@ export class AccountRepository extends Repository {
         }
       }
     });
+
+    // Account suspended
+    if (has(response.body.logged_in_user, 'is_active') && !response.body.logged_in_user.is_active) {
+      throw new IgAccountSuspendedError();
+    }
+
     return response.body.logged_in_user;
   }
 
@@ -76,14 +94,17 @@ export class AccountRepository extends Repository {
     return `2${sum}`;
   }
 
-  public encryptPassword(password: string): { time: string, encrypted: string } {
+  public encryptPassword(password: string): { time: string; encrypted: string } {
     const randKey = crypto.randomBytes(32);
     const iv = crypto.randomBytes(12);
-    const rsaEncrypted = crypto.publicEncrypt({
-      key: Buffer.from(this.client.state.passwordEncryptionPubKey, 'base64').toString(),
-      // @ts-ignore
-      padding: crypto.constants.RSA_PKCS1_PADDING,
-    }, randKey);
+    const rsaEncrypted = crypto.publicEncrypt(
+      {
+        key: Buffer.from(this.client.state.passwordEncryptionPubKey, 'base64').toString(),
+        // @ts-ignore
+        padding: crypto.constants.RSA_PKCS1_PADDING,
+      },
+      randKey,
+    );
     const cipher = crypto.createCipheriv('aes-256-gcm', randKey, iv);
     const time = Math.floor(Date.now() / 1000).toString();
     cipher.setAAD(Buffer.from(time));
@@ -97,8 +118,10 @@ export class AccountRepository extends Repository {
         Buffer.from([1, this.client.state.passwordEncryptionKeyId]),
         iv,
         sizeBuffer,
-        rsaEncrypted, authTag, aesEncrypted])
-        .toString('base64'),
+        rsaEncrypted,
+        authTag,
+        aesEncrypted,
+      ]).toString('base64'),
     };
   }
 

--- a/src/responses/account.repository.login.response.ts
+++ b/src/responses/account.repository.login.response.ts
@@ -7,6 +7,7 @@ export interface AccountRepositoryLoginResponseLogged_in_user {
   username: string;
   full_name: string;
   is_private: boolean;
+  is_active?: boolean;
   profile_pic_url: string;
   profile_pic_id: string;
   is_verified: boolean;


### PR DESCRIPTION
- Catch error for invalid username or password, and suspended account
- Add error class for a suspended account

Currently, Instagram returns almost an Identical error response for an invalid password and username, so it just throws `IgResponseError` instead of its own error class. To fix this, I add a condition to check for the `error_title`, But we can also check the difference from their buttons.

### Response for invalid username
```
{
    "message": "The username you entered doesn't appear to belong to an account. Please check your username and try again.",
    "status": "fail",
    "error_title": "Incorrect username",
    "buttons": [
        {
            "title": "Try Again",
            "action": "dismiss"
        }
    ],
    "invalid_credentials": true,
    "exception_name": "UserInvalidCredentials"
}
```
### Response for invalid password
```
{
    "message": "We couldn't find an account with the username [my username]. Check the username you entered and try again.",
    "status": "fail",
    "error_title": "Username Not Found",
    "buttons": [
        {
            "title": "Try Again",
            "action": "dismiss"
        },
        {
            "title": "Recover Your Account",
            "action": "show_recovery_challenge"
        }
    ],
    "invalid_credentials": true,
    "exception_name": "UserInvalidCredentials"
}
```

Instagram also did not return an error response for a suspended account when you log in. instead, they returned a successful response with the username set as `Instagram User` and they also added the `is_active` key to the response that is set to `false`